### PR TITLE
docs(roadmap): mark Phase 3 (H5 Remote Access) as complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to DreamCoder will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Phase 3 — H5 Remote Access landed**: access desktop sessions from a phone or browser over LAN. Includes the H5 access toggle with token rotation, QR-code pairing, mobile chat UI, WebSocket remote bridge, and a strict CORS / loopback-vs-token request classifier (`src/server/h5AccessPolicy.ts`).
+- Direct-connect session manager and headless connect entrypoint (`src/server/createDirectConnectSession.ts`, `connectHeadless.ts`).
+- Static H5 asset serving with long-lived cache for `/assets/*` (`src/server/staticH5.ts`).
+- H5 Access settings tab is now visible by default in Settings.
 - Performance optimization: bundle splitting (manualChunks), lazy-loaded Settings page, dynamic KaTeX/Mermaid imports.
 - Performance optimization: sessionsById Map index for O(1) session lookups.
 - Performance optimization: throttle/debounce on noisy polling loops.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Claude Code 非常强大，但它是一个纯命令行工具 (CLI-only)。
 - [x] **Phase 1**: 桌面端 GUI + 多模型支持 + 项目工作台
 - [x] **Phase 2**: CLI 后端集成 + Computer Use + MCP + Skills + Agent Teams
 - [x] **Phase 2.5**: 性能优化 — bundle 拆分、轮询节流、终端 LRU、sessionStore 重构
-- [ ] **Phase 3**: H5 远程访问 (手机/浏览器接入桌面端会话)
+- [x] **Phase 3**: H5 远程访问 (手机/浏览器接入桌面端会话)
 - [ ] **Phase 4**: IM 适配器集成 (飞书/钉钉/Telegram/微信)
 - [ ] **Phase 5**: Release 自动化 + 自动更新
 

--- a/README_en.md
+++ b/README_en.md
@@ -75,7 +75,7 @@ DreamCoder brings a **native desktop interface** to that powerful engine.
 - [x] **Phase 1**: Desktop App (Windows/macOS) + Multi-Provider System + Project Workspace
 - [x] **Phase 2**: CLI Backend Integration + Computer Use + MCP + Skills + Agent Teams
 - [x] **Phase 2.5**: Performance — bundle splitting, polling throttle, terminal LRU, sessionStore refactor
-- [ ] **Phase 3**: H5 Remote Access (access desktop sessions from phone/browser)
+- [x] **Phase 3**: H5 Remote Access (access desktop sessions from phone/browser)
 - [ ] **Phase 4**: IM Adapter Integration (Feishu, DingTalk, Telegram, WeChat)
 - [ ] **Phase 5**: Release Automation + Auto-update
 

--- a/docs/ROADMAP_en.md
+++ b/docs/ROADMAP_en.md
@@ -32,15 +32,16 @@
 - [x] Scheduled task poll failure toast
 - [x] Configurable max terminal count
 
-## Phase 3 — H5 Remote Access
+## Phase 3 — H5 Remote Access ✅
 
 Expose desktop capabilities to mobile browsers via LAN or reverse proxy.
 
-- [ ] H5 access toggle & token management
-- [ ] Mobile chat UI adaptation
-- [ ] WebSocket remote bridge
-- [ ] CORS security policy
-- [ ] Reverse proxy deployment guide
+- [x] H5 access toggle & token management
+- [x] Mobile chat UI adaptation
+- [x] WebSocket remote bridge
+- [x] CORS security policy
+- [x] LAN direct-connect + QR pairing
+- [ ] Reverse proxy deployment guide (in progress)
 
 See: [Issue #3](https://github.com/GoDiao/dreamcoder/issues/3)
 

--- a/docs/ROADMAP_zh.md
+++ b/docs/ROADMAP_zh.md
@@ -32,15 +32,16 @@
 - [x] 定时任务轮询失败 Toast 提示
 - [x] 可配置终端数量上限
 
-## Phase 3 — H5 远程访问
+## Phase 3 — H5 远程访问 ✅
 
 将桌面端能力通过局域网或反向代理暴露到手机浏览器。
 
-- [ ] H5 访问开关与 Token 管理
-- [ ] 手机端聊天 UI 适配
-- [ ] WebSocket 远程桥接
-- [ ] CORS 安全策略
-- [ ] 反向代理部署指南
+- [x] H5 访问开关与 Token 管理
+- [x] 手机端聊天 UI 适配
+- [x] WebSocket 远程桥接
+- [x] CORS 安全策略
+- [x] LAN 直连 + 二维码配对
+- [ ] 反向代理部署指南（仍在编写）
 
 参考: [Issue #3](https://github.com/GoDiao/dreamcoder/issues/3)
 


### PR DESCRIPTION
## Summary

Phase 3 — H5 Remote Access has actually shipped (`src/server/h5AccessPolicy.ts`, `createDirectConnectSession.ts`, `staticH5.ts`, `desktop/src/components/settings/H5AccessSettings.tsx`, plus `feat: unhide H5 Access tab in Settings`). The roadmap docs hadn't been updated yet — this PR fixes that.

- README (zh + en): Phase 3 ticked
- ROADMAP (zh + en): Phase 3 marked ✅, four sub-tasks checked, reverse-proxy guide left open
- CHANGELOG [Unreleased]: new entry documenting the H5 Remote Access landing

Companion changes outside this PR:
- Contributor Hub issue #15 updated to reflect Phase 3 done + new RFC link
- New RFC #19 opened for Phase 4 (IM adapter framework)

## Test plan

- [x] `grep -n "Phase 3" README.md README_en.md docs/ROADMAP_*.md CHANGELOG.md` shows Phase 3 marked complete in all 5 files
- [x] No merge markers introduced