### PR TITLE
chore(release): v0.4.0 — H5 Remote Access milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to DreamCoder will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-06-13
+
 ### Added
 - **Phase 3 — H5 Remote Access landed**: access desktop sessions from a phone or browser over LAN. Includes the H5 access toggle with token rotation, QR-code pairing, mobile chat UI, WebSocket remote bridge, and a strict CORS / loopback-vs-token request classifier (`src/server/h5AccessPolicy.ts`).
 - Direct-connect session manager and headless connect entrypoint (`src/server/createDirectConnectSession.ts`, `connectHeadless.ts`).
@@ -19,13 +21,24 @@ All notable changes to DreamCoder will be documented in this file.
 - Scheduled-task poll failure toast after 3 consecutive errors.
 - `useSessionById(id)` hook for memoized O(1) session lookups.
 - E2E benchmark suite (store-e2e, TTI, Tauri RSS).
+- Project website rebuilt on Vite (replaces the Docusaurus prototype) with a marketing landing page, architecture diagram, and 8 documentation pages (install, Computer Use, MCP, sessions/terminal, dev guide, troubleshooting, etc.).
+- Community setup: structured `.github/ISSUE_TEMPLATE` (bug / feature / good-first-issue + Discussions routing), good-first-issue / help-wanted README badges, CONTRIBUTING 5-minute Quick Start (zh + en), pinned Contributor Hub issue, and 10 curated onboarding issues.
+- Bilingual ROADMAP and CONTRIBUTING (zh + en).
+- H5 Access settings tab unhidden in Settings.
 
 ### Changed
 - sessionStore: removed dual `sessionsById` state; replaced with module-level memoized cache.
 - Sidebar, StatusBar, ActiveSession migrated to `useSessionById`.
+- Roadmap: Phase 3 marked complete; Phase 4 (IM adapters) opened as RFC #19.
+- README screenshots refreshed; product copy softened (removed "first-class" marketing language).
 
 ### Fixed
 - Midnight theme now correctly maps to dark color scheme.
+- Various README encoding issues (mojibake).
+- `switchConfig` removed from `colorMode` (deprecated upstream).
+
+### Removed
+- `docs/activity_rule.md` is no longer tracked (contest-specific doc moved out of the repo).
 
 ## [0.3.0] — 2026-05-31
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "dreamcoder-desktop",
   "private": false,
   "description": "DreamCoder — AI Coding Agent Desktop App",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "author": "GoDiao",
   "license": "MIT",
   "type": "module",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dreamcoder-desktop"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/nicegui/static/tauri-schema-v2.json",
   "productName": "DreamCoder",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "identifier": "com.dreamcoder.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dreamcoder",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cut **v0.4.0** — the H5 Remote Access milestone release.

- Bump version in `package.json`, `desktop/package.json`, `desktop/src-tauri/Cargo.toml`, `desktop/src-tauri/tauri.conf.json` → `0.4.0`
- Move CHANGELOG `[Unreleased]` content into a dated `0.4.0` section
- Add a brief `Community / Docs / Removed` block to the CHANGELOG to cover this cycle's housekeeping

After this merges, I'll:
1. Tag `v0.4.0` on master
2. Push the Windows installer artifacts (currently building locally)
3. Publish the GitHub release with user-facing notes

## Test plan

- [x] `grep version package.json desktop/package.json` returns 0.4.0
- [x] `grep version desktop/src-tauri/Cargo.toml desktop/src-tauri/tauri.conf.json` returns 0.4.0
- [x] CHANGELOG renders cleanly (no merge markers, dated 0.4.0 section above 0.3.0)
- [ ] Local Windows build succeeds (`cd desktop && bun run build`) — running in background