### PR TITLE
feat(ui): unified motion system + Modal/BottomSheet refactor

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "dreamcoder-desktop"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "portable-pty",

--- a/desktop/src/components/controls/PermissionModeSelector.tsx
+++ b/desktop/src/components/controls/PermissionModeSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import DOMPurify from 'dompurify'
 import { createPortal } from 'react-dom'
 import { useSettingsStore } from '../../stores/settingsStore'
@@ -37,6 +37,8 @@ export function PermissionModeSelector({ workDir: workDirProp, compact = false, 
   const sessions = useSessionStore((s) => s.sessions)
   const [open, setOpen] = useState(false)
   const [confirmDialog, setConfirmDialog] = useState(false)
+  const [confirmMounted, setConfirmMounted] = useState(false)
+  const [confirmVisible, setConfirmVisible] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -119,6 +121,19 @@ export function PermissionModeSelector({ workDir: workDirProp, compact = false, 
       document.removeEventListener('keydown', handleEsc)
     }
   }, [open])
+
+  useEffect(() => {
+    if (confirmDialog) {
+      setConfirmMounted(true)
+      const frame = window.requestAnimationFrame(() => setConfirmVisible(true))
+      return () => window.cancelAnimationFrame(frame)
+    }
+    setConfirmVisible(false)
+    const timer = window.setTimeout(() => setConfirmMounted(false), 180)
+    return () => window.clearTimeout(timer)
+  }, [confirmDialog])
+
+  const closeConfirmDialog = useCallback(() => setConfirmDialog(false), [])
 
   const permissionOptions = (
     <div id={menuId} ref={menuRef} role="menu">
@@ -207,17 +222,18 @@ export function PermissionModeSelector({ workDir: workDirProp, compact = false, 
             {permissionOptions}
           </MobileBottomSheet>
         ) : (
-          <div id={menuId} ref={menuRef} role="menu" className="absolute left-0 bottom-full mb-2 w-[320px] rounded-xl bg-[var(--color-surface-container-lowest)] border border-[var(--color-border)] shadow-[var(--shadow-dropdown)] z-50 py-2">
+          <div id={menuId} ref={menuRef} role="menu" className="motion-menu absolute left-0 bottom-full z-50 mb-2 w-[320px] rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] py-2 shadow-[var(--shadow-dropdown)]" data-state="open">
             {menuContent}
           </div>
         )
       )}
 
       {/* Bypass confirmation dialog */}
-      {confirmDialog && createPortal(
-        <div className={`fixed inset-0 z-[100] flex items-center justify-center bg-black/40 ${isMobile ? 'px-4' : 'pl-[var(--sidebar-width)] pr-4'}`} onClick={() => setConfirmDialog(false)}>
+      {confirmMounted && createPortal(
+        <div className={`motion-modal-backdrop fixed inset-0 z-[100] flex items-center justify-center bg-black/40 ${isMobile ? 'px-4' : 'pl-[var(--sidebar-width)] pr-4'}`} data-state={confirmVisible ? 'open' : 'closed'} onClick={closeConfirmDialog}>
           <div
-            className={`${isMobile ? 'w-full max-w-md' : 'w-[420px]'} rounded-2xl bg-[var(--color-surface-container-lowest)] border border-[var(--color-border)] shadow-[var(--shadow-dropdown)] overflow-hidden`}
+            className={`motion-modal-panel ${isMobile ? 'w-full max-w-md' : 'w-[420px]'} overflow-hidden rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] shadow-[var(--shadow-dropdown)]`}
+            data-state={confirmVisible ? 'open' : 'closed'}
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
@@ -257,7 +273,7 @@ export function PermissionModeSelector({ workDir: workDirProp, compact = false, 
             {/* Actions */}
             <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-[var(--color-border)] bg-[var(--color-surface-container-low)]">
               <button
-                onClick={() => setConfirmDialog(false)}
+                onClick={closeConfirmDialog}
                 className="px-4 py-2 text-xs font-semibold text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] rounded-lg transition-colors"
               >
                 {t('common.cancel')}

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -42,6 +42,8 @@ export function AppShell() {
   const [h5StartupError, setH5StartupError] = useState<H5ConnectionRequiredError | null>(null)
   const [bootstrapNonce, setBootstrapNonce] = useState(0)
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
+  const [mobileSidebarMounted, setMobileSidebarMounted] = useState(false)
+  const [mobileSidebarVisible, setMobileSidebarVisible] = useState(false)
   const t = useTranslation()
   const tauriRuntime = isTauriRuntime()
   const isMobileShell = useMobileViewport() && !tauriRuntime
@@ -53,6 +55,8 @@ export function AppShell() {
   )
   const wasMobileShellRef = useRef(false)
   const effectiveSidebarOpen = isMobileShell ? mobileSidebarOpen : sidebarOpen
+  const effectiveSidebarMounted = !isMobileShell || mobileSidebarMounted
+  const effectiveSidebarVisible = isMobileShell ? mobileSidebarVisible : sidebarOpen
   const activeTab = tabs.find((tab) => tab.sessionId === activeTabId)
   const isActiveChatTab = isChatTab(activeTab)
   const mobileSessionTitle = activeSession?.title || activeTab?.title || t('session.untitled')
@@ -162,6 +166,22 @@ export function AppShell() {
     useTabStore.setState({ activeTabId: null })
   }, [activeTab, activeTabId, isMobileShell, ready, setActiveTab, tabs])
 
+  useEffect(() => {
+    if (!isMobileShell) {
+      setMobileSidebarMounted(false)
+      setMobileSidebarVisible(false)
+      return
+    }
+    if (mobileSidebarOpen) {
+      setMobileSidebarMounted(true)
+      const frame = window.requestAnimationFrame(() => setMobileSidebarVisible(true))
+      return () => window.cancelAnimationFrame(frame)
+    }
+    setMobileSidebarVisible(false)
+    const timer = window.setTimeout(() => setMobileSidebarMounted(false), 280)
+    return () => window.clearTimeout(timer)
+  }, [isMobileShell, mobileSidebarOpen])
+
   const setEffectiveSidebarOpen = (open: boolean) => {
     if (isMobileShell) {
       setMobileSidebarOpen(open)
@@ -207,10 +227,11 @@ export function AppShell() {
 
   return (
     <div className={`app-shell app-shell-viewport flex overflow-hidden bg-[var(--color-surface)]${isMobileShell ? ' app-shell--mobile' : ''}`}>
-      {isMobileShell && effectiveSidebarOpen ? (
+      {isMobileShell && effectiveSidebarMounted ? (
         <button
           type="button"
           data-testid="sidebar-backdrop"
+          data-state={effectiveSidebarVisible ? 'open' : 'closed'}
           className="app-shell-backdrop fixed inset-0 z-40 border-0 p-0"
           aria-label={t('sidebar.collapse')}
           onClick={() => setEffectiveSidebarOpen(false)}
@@ -219,13 +240,13 @@ export function AppShell() {
       <div
         id="sidebar-shell"
         data-testid="sidebar-shell"
-        data-state={effectiveSidebarOpen ? 'open' : 'closed'}
+        data-state={effectiveSidebarVisible ? 'open' : 'closed'}
         data-mobile={isMobileShell ? 'true' : 'false'}
         className={`sidebar-shell${isMobileShell ? ' sidebar-shell--mobile' : ''}`}
         style={isMobileShell ? undefined : { '--sidebar-width': `${sidebarWidth}px` } as React.CSSProperties}
         {...sidebarHiddenProps}
       >
-        {!isMobileShell || effectiveSidebarOpen ? (
+        {effectiveSidebarMounted ? (
           <Sidebar isMobile={isMobileShell} onRequestClose={() => setEffectiveSidebarOpen(false)} />
         ) : null}
       </div>
@@ -234,7 +255,7 @@ export function AppShell() {
       ) : null}
       <main
         id="content-area"
-        data-sidebar-state={effectiveSidebarOpen ? 'open' : 'closed'}
+        data-sidebar-state={effectiveSidebarVisible ? 'open' : 'closed'}
         className={`min-w-0 flex-1 flex flex-col overflow-hidden${isMobileShell ? ' app-shell-main--mobile' : ''}`}
       >
         {isMobileShell ? (

--- a/desktop/src/components/layout/ContentRouter.tsx
+++ b/desktop/src/components/layout/ContentRouter.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { useTabStore } from '../../stores/tabStore'
 import { EmptySession } from '../../pages/EmptySession'
 import { ActiveSession } from '../../pages/ActiveSession'
@@ -11,6 +11,13 @@ export function ContentRouter() {
   const tabs = useTabStore((s) => s.tabs)
   const activeTabType = tabs.find((t) => t.sessionId === activeTabId)?.type
   const terminalTabs = tabs.filter((tab) => tab.type === 'terminal')
+  const [pageAnimating, setPageAnimating] = useState(false)
+
+  useEffect(() => {
+    setPageAnimating(false)
+    const frame = window.requestAnimationFrame(() => setPageAnimating(true))
+    return () => window.cancelAnimationFrame(frame)
+  }, [activeTabId, activeTabType])
 
   let page: ReactNode = null
   if (!activeTabId || !activeTabType) {
@@ -26,7 +33,7 @@ export function ContentRouter() {
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">
       {page && (
-        <div className="absolute inset-0 z-10 flex min-h-0 flex-col overflow-hidden">
+        <div className={`absolute inset-0 z-10 flex min-h-0 flex-col overflow-hidden motion-page-transition${pageAnimating ? ' motion-page-transition--visible' : ''}`}>
           {page}
         </div>
       )}
@@ -38,7 +45,7 @@ export function ContentRouter() {
             key={tab.sessionId}
             aria-hidden={!visible}
             data-testid={`terminal-tab-panel-${tab.sessionId}`}
-            className={`absolute inset-0 flex min-h-0 flex-col overflow-hidden ${
+            className={`absolute inset-0 flex min-h-0 flex-col overflow-hidden transition-opacity duration-150 ease-out ${
               visible ? 'z-20 opacity-100' : 'pointer-events-none z-0 opacity-0'
             }`}
           >

--- a/desktop/src/components/layout/OpenProjectMenu.tsx
+++ b/desktop/src/components/layout/OpenProjectMenu.tsx
@@ -133,7 +133,8 @@ export function OpenProjectMenu({ path }: Props) {
         <div
           ref={menuRef}
           role="menu"
-          className="fixed z-50 min-w-[220px] overflow-hidden rounded-[12px] border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-[var(--shadow-dropdown)]"
+          className="motion-menu fixed z-50 min-w-[220px] overflow-hidden rounded-[12px] border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-[var(--shadow-dropdown)]"
+          data-state="open"
           style={{ top: rect.bottom + 6, right: Math.max(12, window.innerWidth - rect.right) }}
         >
           {targets.map((target) => (

--- a/desktop/src/components/layout/Sidebar.tsx
+++ b/desktop/src/components/layout/Sidebar.tsx
@@ -837,9 +837,7 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
               {visibleProjectGroups.map((project) => {
                 const projectCollapsed = collapsedProjectKeys.has(project.key)
                 const sessionsExpanded = expandedProjectKeys.has(project.key)
-                const visibleItems = projectCollapsed
-                  ? []
-                  : getVisibleProjectSessions(project.sessions, sessionsExpanded, activeTabId)
+                const visibleItems = projectCollapsed ? [] : getVisibleProjectSessions(project.sessions, sessionsExpanded, activeTabId)
                 const hiddenCount = project.sessions.length - visibleItems.length
                 const groupIds = project.sessions.map((session) => session.id)
                 const groupSelectedCount = groupIds.filter((id) => selectedSessionIds.has(id)).length
@@ -934,8 +932,8 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
                         )}
                       </div>
                     </div>
-                    {!projectCollapsed && (
-                      <div className="mt-0.5 pl-0">
+                    <div className="motion-collapse mt-0.5 pl-0" data-state={projectCollapsed ? 'closed' : 'open'}>
+                      <div>
                         <div
                           className={hasInternalScroll ? 'max-h-[420px] overflow-y-auto pr-1' : undefined}
                           data-testid={`sidebar-project-session-list-${domSafeProjectKey(project.key)}`}
@@ -1031,7 +1029,7 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
                           </div>
                         )}
                       </div>
-                    )}
+                    </div>
                     {dropAfter && (
                       <div className="pointer-events-none absolute -bottom-1 left-1 right-1 z-10 h-0.5 rounded-full bg-[var(--color-brand)]" />
                     )}
@@ -1068,7 +1066,8 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
 
       {contextMenu && (
         <div
-          className="fixed z-50 min-w-[140px] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] py-1"
+          className="motion-menu fixed z-50 min-w-[140px] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] py-1"
+          data-state="open"
           style={{ left: contextMenu.x, top: contextMenu.y, boxShadow: 'var(--shadow-dropdown)' }}
         >
           <button
@@ -1097,7 +1096,8 @@ export function Sidebar({ isMobile = false, onRequestClose }: SidebarProps) {
         return (
           <div
             role="menu"
-            className="fixed z-50 min-w-[230px] overflow-hidden rounded-[18px] border border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] py-2 shadow-[var(--shadow-dropdown)]"
+            className="motion-menu fixed z-50 min-w-[230px] overflow-hidden rounded-[18px] border border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] py-2 shadow-[var(--shadow-dropdown)]"
+            data-state="open"
             style={positionProjectMenu(projectContextMenu.x, projectContextMenu.y)}
             onClick={(event) => event.stopPropagation()}
           >
@@ -1340,11 +1340,11 @@ function ProjectHeaderMenu({
 }) {
   const width = type === 'sort' ? 230 : type === 'create' ? 250 : 270
   const style: React.CSSProperties = { left: x, top: y, width, boxShadow: 'var(--shadow-dropdown)' }
-  const className = 'fixed z-50 overflow-hidden rounded-[18px] border border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] py-2 shadow-[var(--shadow-dropdown)]'
+  const className = 'motion-menu fixed z-50 overflow-hidden rounded-[18px] border border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] py-2 shadow-[var(--shadow-dropdown)]'
 
   if (type === 'create') {
     return (
-      <div role="menu" className={className} style={style} onClick={(event) => event.stopPropagation()}>
+      <div role="menu" className={className} data-state="open" style={style} onClick={(event) => event.stopPropagation()}>
         <HeaderMenuItem icon={<SquarePen size={18} aria-hidden="true" />} onClick={onCreateBlank}>
           {t('sidebar.newBlankProject')}
         </HeaderMenuItem>
@@ -1357,7 +1357,7 @@ function ProjectHeaderMenu({
 
   if (type === 'organize') {
     return (
-      <div role="menu" className={className} style={style} onClick={(event) => event.stopPropagation()}>
+      <div role="menu" className={className} data-state="open" style={style} onClick={(event) => event.stopPropagation()}>
         <HeaderMenuItem icon={<Folder size={18} aria-hidden="true" />} checked={organization === 'project'} onClick={() => onSetOrganization('project')}>
           {t('sidebar.organizeByProject')}
         </HeaderMenuItem>
@@ -1373,7 +1373,7 @@ function ProjectHeaderMenu({
 
   if (type === 'sort') {
     return (
-      <div role="menu" className={className} style={style} onClick={(event) => event.stopPropagation()}>
+      <div role="menu" className={className} data-state="open" style={style} onClick={(event) => event.stopPropagation()}>
         <HeaderMenuItem icon={<Clock size={18} aria-hidden="true" />} checked={sortBy === 'createdAt'} onClick={() => onSetSortBy('createdAt')}>
           {t('sidebar.sortByCreatedAt')}
         </HeaderMenuItem>

--- a/desktop/src/components/layout/TabBar.tsx
+++ b/desktop/src/components/layout/TabBar.tsx
@@ -14,6 +14,7 @@ import { useTerminalPanelStore } from '../../stores/terminalPanelStore'
 import { useTranslation } from '../../i18n'
 import { WindowControls, showWindowControls } from './WindowControls'
 import { OpenProjectMenu } from './OpenProjectMenu'
+import { Modal } from '../shared/Modal'
 import { Folder, FolderOpen, SquareTerminal } from 'lucide-react'
 
 const TAB_WIDTH = 180
@@ -74,6 +75,7 @@ export function TabBar() {
   const [canScrollRight, setCanScrollRight] = useState(false)
   const [contextMenu, setContextMenu] = useState<{ sessionId: string; x: number; y: number } | null>(null)
   const [pendingCloseRequest, setPendingCloseRequest] = useState<PendingCloseRequest | null>(null)
+  const [closeConfirmOpen, setCloseConfirmOpen] = useState(false)
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
   const [draggingSessionId, setDraggingSessionId] = useState<string | null>(null)
   const [dragOffsetX, setDragOffsetX] = useState(0)
@@ -194,11 +196,27 @@ export function TabBar() {
 
     if (runningSessionIds.length > 0) {
       setPendingCloseRequest({ tabs: targetTabs, runningSessionIds })
+      setCloseConfirmOpen(true)
       return
     }
 
     closeTabsWithPolicy(targetTabs, [], false)
   }, [closeTabsWithPolicy, getRunningSessionIds])
+
+  const closeConfirmDialog = useCallback(() => {
+    setCloseConfirmOpen(false)
+  }, [])
+
+  const clearPendingCloseRequest = useCallback(() => {
+    setPendingCloseRequest(null)
+  }, [])
+
+  const confirmCloseTabs = useCallback((stopRunning: boolean) => {
+    if (!pendingCloseRequest) return
+    closeTabsWithPolicy(pendingCloseRequest.tabs, pendingCloseRequest.runningSessionIds, stopRunning)
+    setCloseConfirmOpen(false)
+    setPendingCloseRequest(null)
+  }, [closeTabsWithPolicy, pendingCloseRequest])
 
   const handleClose = (sessionId: string) => {
     const tab = tabs.find((t) => t.sessionId === sessionId)
@@ -409,7 +427,8 @@ export function TabBar() {
 
       {contextMenu && (
         <div
-          className="fixed z-50 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-[var(--radius-md)] py-1 min-w-[160px]"
+          className="motion-menu fixed z-50 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-[var(--radius-md)] py-1 min-w-[160px]"
+          data-state="open"
           style={{ left: contextMenu.x, top: contextMenu.y, boxShadow: 'var(--shadow-dropdown)' }}
         >
           <button
@@ -446,47 +465,46 @@ export function TabBar() {
         </div>
       )}
 
-      {pendingCloseRequest && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/30">
-          <div className="bg-[var(--color-surface)] rounded-xl border border-[var(--color-border)] p-6 max-w-sm w-full mx-4" style={{ boxShadow: 'var(--shadow-dropdown)' }}>
-            <h3 className="text-sm font-semibold text-[var(--color-text-primary)] mb-2">
+      <Modal
+        open={closeConfirmOpen}
+        onClose={closeConfirmDialog}
+        title={pendingCloseRequest
+          ? pendingCloseRequest.runningSessionIds.length > 1
+            ? t('tabs.closeAllConfirmTitle')
+            : t('tabs.closeConfirmTitle')
+          : undefined}
+        width={420}
+        onExited={clearPendingCloseRequest}
+        footer={pendingCloseRequest && (
+          <>
+            <button onClick={closeConfirmDialog} className="px-3 py-1.5 text-xs rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]">
+              {t('common.cancel')}
+            </button>
+            <button
+              onClick={() => confirmCloseTabs(false)}
+              className="px-3 py-1.5 text-xs rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]"
+            >
+              {t('tabs.closeConfirmKeep')}
+            </button>
+            <button
+              onClick={() => confirmCloseTabs(true)}
+              className="px-3 py-1.5 text-xs rounded-lg bg-[var(--color-brand)] text-white hover:opacity-90"
+            >
               {pendingCloseRequest.runningSessionIds.length > 1
-                ? t('tabs.closeAllConfirmTitle')
-                : t('tabs.closeConfirmTitle')}
-            </h3>
-            <p className="text-xs text-[var(--color-text-secondary)] mb-4">
-              {pendingCloseRequest.runningSessionIds.length > 1
-                ? t('tabs.closeAllConfirmMessage', { count: pendingCloseRequest.runningSessionIds.length })
-                : t('tabs.closeConfirmMessage')}
-            </p>
-            <div className="flex justify-end gap-2">
-              <button onClick={() => setPendingCloseRequest(null)} className="px-3 py-1.5 text-xs rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]">
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={() => {
-                  closeTabsWithPolicy(pendingCloseRequest.tabs, pendingCloseRequest.runningSessionIds, false)
-                  setPendingCloseRequest(null)
-                }}
-                className="px-3 py-1.5 text-xs rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]"
-              >
-                {t('tabs.closeConfirmKeep')}
-              </button>
-              <button
-                onClick={() => {
-                  closeTabsWithPolicy(pendingCloseRequest.tabs, pendingCloseRequest.runningSessionIds, true)
-                  setPendingCloseRequest(null)
-                }}
-                className="px-3 py-1.5 text-xs rounded-lg bg-[var(--color-brand)] text-white hover:opacity-90"
-              >
-                {pendingCloseRequest.runningSessionIds.length > 1
-                  ? t('tabs.closeAllConfirmStop')
-                  : t('tabs.closeConfirmStop')}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+                ? t('tabs.closeAllConfirmStop')
+                : t('tabs.closeConfirmStop')}
+            </button>
+          </>
+        )}
+      >
+        {pendingCloseRequest && (
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            {pendingCloseRequest.runningSessionIds.length > 1
+              ? t('tabs.closeAllConfirmMessage', { count: pendingCloseRequest.runningSessionIds.length })
+              : t('tabs.closeConfirmMessage')}
+          </p>
+        )}
+      </Modal>
     </div>
   )
 }

--- a/desktop/src/components/shared/Dropdown.tsx
+++ b/desktop/src/components/shared/Dropdown.tsx
@@ -58,13 +58,13 @@ export function Dropdown<T extends string>({
       {open && (
         <div
           className={`
-            absolute z-50 mt-1 rounded-[var(--radius-lg)]
+            motion-menu absolute z-50 mt-1 rounded-[var(--radius-lg)]
             bg-[var(--color-surface-container-lowest)] border border-[var(--color-border)]
             shadow-[var(--shadow-dropdown)]
-            animate-in fade-in slide-in-from-top-1
             ${maxHeight ? 'overflow-y-auto' : 'overflow-hidden'}
             ${align === 'right' ? 'right-0' : 'left-0'}
           `}
+          data-state="open"
           style={{ width, maxHeight }}
         >
           {items.map((item, i) => (

--- a/desktop/src/components/shared/MobileBottomSheet.tsx
+++ b/desktop/src/components/shared/MobileBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode, type Ref } from 'react'
+import { useEffect, useState, type ReactNode, type Ref } from 'react'
 import { createPortal } from 'react-dom'
 
 type Props = {
@@ -34,6 +34,20 @@ export function MobileBottomSheet({
   panelRef,
   testId,
 }: Props) {
+  const [mounted, setMounted] = useState(open)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true)
+      const frame = window.requestAnimationFrame(() => setVisible(true))
+      return () => window.cancelAnimationFrame(frame)
+    }
+    setVisible(false)
+    const timer = window.setTimeout(() => setMounted(false), 220)
+    return () => window.clearTimeout(timer)
+  }, [open])
+
   useEffect(() => {
     if (!open) return
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -43,10 +57,10 @@ export function MobileBottomSheet({
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [open, onClose])
 
-  if (!open) return null
+  if (!mounted) return null
 
   return createPortal(
-    <div className="fixed inset-0 z-[10000] bg-black/25" onClick={onClose}>
+    <div className="motion-bottom-sheet-backdrop fixed inset-0 z-[10000] bg-black/25" data-state={visible ? 'open' : 'closed'} onClick={onClose}>
       <div
         ref={panelRef}
         id={id}
@@ -54,7 +68,8 @@ export function MobileBottomSheet({
         aria-modal={role === 'dialog' ? true : undefined}
         aria-label={ariaLabel ?? (typeof title === 'string' ? title : undefined)}
         data-testid={testId}
-        className={`absolute inset-x-0 bottom-0 flex max-h-[min(78dvh,640px)] min-h-0 flex-col overflow-hidden rounded-t-2xl border-x-0 border-y border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] shadow-[0_-18px_48px_rgba(54,35,28,0.22)] ${panelClassName}`}
+        className={`motion-bottom-sheet-panel absolute inset-x-0 bottom-0 flex max-h-[min(78dvh,640px)] min-h-0 flex-col overflow-hidden rounded-t-2xl border-x-0 border-y border-[var(--color-border)] bg-[var(--color-surface-container-lowest)] shadow-[0_-18px_48px_rgba(54,35,28,0.22)] ${panelClassName}`}
+        data-state={visible ? 'open' : 'closed'}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="shrink-0 border-b border-[var(--color-border)] px-4 py-3">

--- a/desktop/src/components/shared/Modal.tsx
+++ b/desktop/src/components/shared/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 
 type ModalProps = {
@@ -8,31 +8,60 @@ type ModalProps = {
   children: ReactNode
   width?: number
   footer?: ReactNode
+  onExited?: () => void
 }
 
-export function Modal({ open, onClose, title, children, width = 560, footer }: ModalProps) {
+export function Modal({ open, onClose, title, children, width = 560, footer, onExited }: ModalProps) {
+  const [mounted, setMounted] = useState(open)
+  const [visible, setVisible] = useState(false)
+  const onExitedRef = useRef(onExited)
+
+  useEffect(() => {
+    onExitedRef.current = onExited
+  }, [onExited])
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true)
+      const frame = window.requestAnimationFrame(() => setVisible(true))
+      return () => window.cancelAnimationFrame(frame)
+    }
+    if (!mounted) return
+    setVisible(false)
+    const timer = window.setTimeout(() => {
+      setMounted(false)
+      onExitedRef.current?.()
+    }, 180)
+    return () => window.clearTimeout(timer)
+  }, [mounted, open])
+
+  const handleClose = useCallback(() => {
+    if (!open) return
+    onClose()
+  }, [onClose, open])
+
   useEffect(() => {
     if (!open) return
     const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') handleClose()
     }
     document.addEventListener('keydown', handleEsc)
     return () => document.removeEventListener('keydown', handleEsc)
-  }, [open, onClose])
+  }, [handleClose, open])
 
-  if (!open) return null
+  if (!mounted) return null
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-[var(--color-overlay-scrim)] transition-opacity duration-200"
-        onClick={onClose}
+        className="motion-modal-backdrop absolute inset-0 bg-[var(--color-overlay-scrim)]"
+        data-state={visible ? 'open' : 'closed'}
+        onClick={handleClose}
       />
 
-      {/* Modal content */}
       <div
-        className="glass-panel relative rounded-[var(--radius-xl)] max-h-[85vh] flex flex-col"
+        className="motion-modal-panel glass-panel relative rounded-[var(--radius-xl)] max-h-[85vh] flex flex-col"
+        data-state={visible ? 'open' : 'closed'}
         style={{ width, maxWidth: 'calc(100vw - 48px)' }}
         role="dialog"
         aria-modal="true"
@@ -43,7 +72,7 @@ export function Modal({ open, onClose, title, children, width = 560, footer }: M
             <h2 className="text-xl font-bold text-[var(--color-text-primary)]">{title}</h2>
             <button
               type="button"
-              onClick={onClose}
+              onClick={handleClose}
               aria-label="Close dialog"
               className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)]"
             >

--- a/desktop/src/pages/Settings.tsx
+++ b/desktop/src/pages/Settings.tsx
@@ -53,6 +53,7 @@ const NETWORK_TIMEOUT_STEP_SECONDS = 30
 
 export function Settings() {
   const [activeTab, setActiveTab] = useState<SettingsTab>('providers')
+  const [tabContentVisible, setTabContentVisible] = useState(false)
   const pendingSettingsTab = useUIStore((s) => s.pendingSettingsTab)
   const t = useTranslation()
 
@@ -61,6 +62,12 @@ export function Settings() {
     setActiveTab(pendingSettingsTab)
     useUIStore.getState().setPendingSettingsTab(null)
   }, [pendingSettingsTab])
+
+  useEffect(() => {
+    setTabContentVisible(false)
+    const frame = window.requestAnimationFrame(() => setTabContentVisible(true))
+    return () => window.cancelAnimationFrame(frame)
+  }, [activeTab])
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-[var(--color-surface)]">
@@ -90,21 +97,23 @@ export function Settings() {
 
         {/* Tab content */}
         <div className="flex-1 overflow-y-auto px-8 py-6">
-          {activeTab === 'providers' && <ProviderSettings />}
-          {activeTab === 'permissions' && <PermissionSettings />}
-          {activeTab === 'activity' && <ActivitySettings />}
-          {activeTab === 'general' && <GeneralSettings />}
-          {activeTab === 'h5Access' && <H5AccessSettings />}
-          {activeTab === 'adapters' && <AdapterSettings />}
-          {activeTab === 'terminal' && <TerminalSettings showPreferences />}
-          {activeTab === 'mcp' && <McpSettings />}
-          {activeTab === 'agents' && <AgentsSettings />}
-          {activeTab === 'skills' && <SkillSettings />}
-          {activeTab === 'memory' && <MemorySettings />}
-          {activeTab === 'plugins' && <PluginSettings />}
-          {activeTab === 'computerUse' && <ComputerUseSettings />}
-          {activeTab === 'diagnostics' && <DiagnosticsSettings />}
-          {activeTab === 'about' && <AboutSettings />}
+          <div className={`motion-page-transition${tabContentVisible ? ' motion-page-transition--visible' : ''}`}>
+            {activeTab === 'providers' && <ProviderSettings />}
+            {activeTab === 'permissions' && <PermissionSettings />}
+            {activeTab === 'activity' && <ActivitySettings />}
+            {activeTab === 'general' && <GeneralSettings />}
+            {activeTab === 'h5Access' && <H5AccessSettings />}
+            {activeTab === 'adapters' && <AdapterSettings />}
+            {activeTab === 'terminal' && <TerminalSettings showPreferences />}
+            {activeTab === 'mcp' && <McpSettings />}
+            {activeTab === 'agents' && <AgentsSettings />}
+            {activeTab === 'skills' && <SkillSettings />}
+            {activeTab === 'memory' && <MemorySettings />}
+            {activeTab === 'plugins' && <PluginSettings />}
+            {activeTab === 'computerUse' && <ComputerUseSettings />}
+            {activeTab === 'diagnostics' && <DiagnosticsSettings />}
+            {activeTab === 'about' && <AboutSettings />}
+          </div>
         </div>
       </div>
     </div>

--- a/desktop/src/theme/globals.css
+++ b/desktop/src/theme/globals.css
@@ -383,6 +383,9 @@
   --statusbar-height: 36px;
   --motion-sidebar-duration: 280ms;
   --motion-sidebar-easing: cubic-bezier(0.22, 1, 0.36, 1);
+  --motion-fast: 150ms;
+  --motion-medium: 220ms;
+  --motion-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
 
   /* Surface aliases */
   --color-surface-sidebar: var(--color-surface-container-low);
@@ -1492,6 +1495,14 @@ button, input, textarea, select, a, [role="button"] {
 
 .app-shell-backdrop {
   background: var(--color-overlay-scrim);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--motion-medium) var(--motion-ease-out);
+}
+
+.app-shell-backdrop[data-state="open"] {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .sidebar-shell {
@@ -1661,12 +1672,134 @@ button, input, textarea, select, a, [role="button"] {
   pointer-events: none;
 }
 
+.motion-fade-scale,
+.motion-menu,
+.motion-bottom-sheet-backdrop,
+.motion-bottom-sheet-panel,
+.motion-modal-backdrop,
+.motion-modal-panel {
+  transition-duration: var(--motion-medium);
+  transition-timing-function: var(--motion-ease-out);
+}
+
+.motion-fade-scale,
+.motion-modal-panel {
+  opacity: 0;
+  transform: scale(0.98);
+  transition-property: opacity, transform;
+}
+
+.motion-fade-scale[data-state="open"],
+.motion-modal-panel[data-state="open"] {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.motion-menu {
+  opacity: 0;
+  transform: translateY(-4px) scale(0.98);
+  transform-origin: top center;
+  transition-property: opacity, transform;
+}
+
+.motion-menu[data-state="open"] {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  animation: motion-menu-enter var(--motion-fast) var(--motion-ease-out);
+}
+
+.motion-bottom-sheet-backdrop,
+.motion-modal-backdrop {
+  opacity: 0;
+  transition-property: opacity;
+}
+
+.motion-bottom-sheet-backdrop[data-state="open"],
+.motion-modal-backdrop[data-state="open"] {
+  opacity: 1;
+}
+
+.motion-bottom-sheet-panel {
+  opacity: 0;
+  transform: translateY(100%);
+  transition-property: opacity, transform;
+}
+
+.motion-bottom-sheet-panel[data-state="open"] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.motion-page-enter {
+  animation: motion-page-enter var(--motion-fast) var(--motion-ease-out);
+}
+
+.motion-page-transition {
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity var(--motion-fast) var(--motion-ease-out),
+    transform var(--motion-fast) var(--motion-ease-out);
+}
+
+.motion-page-transition--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.motion-collapse {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    grid-template-rows var(--motion-medium) var(--motion-ease-out),
+    opacity var(--motion-fast) ease,
+    visibility 0s linear var(--motion-medium);
+}
+
+.motion-collapse[data-state="open"] {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0s;
+}
+
+.motion-collapse > * {
+  min-height: 0;
+  overflow: hidden;
+}
+
+@keyframes motion-page-enter {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes motion-menu-enter {
+  from { opacity: 0; transform: translateY(-4px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .sidebar-shell,
   .sidebar-panel,
   .sidebar-copy,
-  .sidebar-section {
+  .sidebar-section,
+  .app-shell-backdrop,
+  .motion-fade-scale,
+  .motion-menu,
+  .motion-bottom-sheet-backdrop,
+  .motion-bottom-sheet-panel,
+  .motion-modal-backdrop,
+  .motion-modal-panel,
+  .motion-page-transition,
+  .motion-collapse {
     transition-duration: 0.01ms !important;
+  }
+
+  .motion-menu[data-state="open"],
+  .motion-page-enter {
+    animation-duration: 0.01ms !important;
   }
 }
 


### PR DESCRIPTION
## Summary

Pull a long-running set of UI polish changes into the v0.4.0 release. They were already running in my local build, but hadn't been committed yet — this PR puts them in the history so the binaries match the source.

### What changed

- **Motion tokens**: new `--motion-fast` / `--motion-medium` / `--motion-ease-out` in `globals.css`.
- **Unified `.motion-*` classes**: `fade-scale`, `menu`, `bottom-sheet-backdrop/panel`, `modal-backdrop/panel`, `page-enter`, `page-transition`, `collapse`. All driven by `data-state="open"` and gated by `prefers-reduced-motion`.
- **Shared Modal in TabBar**: the close-confirmation overlay now uses `<Modal>` (gained `onExited` + `footer` props) instead of a hand-rolled overlay. All app dialogs now share one animation curve and focus model.
- **Modal / MobileBottomSheet** refactored onto the new motion classes.
- **AppShell backdrop / Sidebar / ContentRouter / Settings page** pick up the `page-transition` and backdrop fade.
- **Context menus + popovers** (Dropdown, PermissionModeSelector, OpenProjectMenu, TabBar context menu) all switched to `motion-menu`, so right-click / popover surfaces behave consistently.

### Stats

12 files changed, +350 / -101.

## Test plan

- [x] `bun run tauri build` succeeds (already produced 0.4.0 installers)
- [x] No console errors / warnings during dev run
- [ ] Verify `prefers-reduced-motion` still disables all new transitions
- [ ] Verify modal close animation completes before content unmounts (the new `onExited` callback)