### PR TITLE
docs: fix dev setup — document the 4-step build sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,17 +140,29 @@ Claude Code 非常强大，但它是一个纯命令行工具 (CLI-only)。
 
 ### 安装与运行
 
+> 这是一个 Bun monorepo（根 + `desktop/` 各有独立 `package.json`），**四步都不能跳**，否则 `tauri dev` 会因为缺 sidecar 二进制 / Tauri CLI 启动失败。
+
 ```bash
-# 1. 克隆仓库
+# 0. 克隆仓库
 git clone https://github.com/GoDiao/dreamcoder.git
 cd dreamcoder
 
-# 2. 安装依赖
+# 1. 安装根工作区依赖（sidecar 运行时：Anthropic SDK / AWS SDK / ink 等）
 bun install
 
-# 3. 启动桌面端开发模式
-cd desktop && bun run dev
+# 2. 安装桌面端依赖（Tauri CLI + React 前端）
+cd desktop && bun install
+
+# 3. 编译 sidecar 二进制（不跑这步，第 4 步会因 externalBin 缺失而失败）
+bun run build:sidecars
+
+# 4. 启动桌面端开发模式
+bun run tauri dev
 ```
+
+> **Linux 用户**：还需要先装好 WebKitGTK / libappindicator / librsvg 等系统库，
+> 详见 [Tauri 官方 prerequisites](https://v2.tauri.app/start/prerequisites/)。
+> 维护者不在 Linux 上日常使用，欢迎 PR 补充发行版具体命令。
 
 ### 配置 AI 模型
 

--- a/README_en.md
+++ b/README_en.md
@@ -108,17 +108,29 @@ See [ROADMAP](docs/ROADMAP_en.md)
 
 ### Installation
 
+> This is a Bun monorepo (root + `desktop/` each have their own `package.json`). **All four steps are required** — skipping any one breaks `tauri dev` (missing sidecar binary or missing Tauri CLI).
+
 ```bash
-# 1. Clone the repository
+# 0. Clone the repo
 git clone https://github.com/GoDiao/dreamcoder.git
 cd dreamcoder
 
-# 2. Install dependencies
+# 1. Install root workspace deps (sidecar runtime — Anthropic SDK, AWS SDK, ink, etc.)
 bun install
 
-# 3. Run in development mode
-cd desktop && bun run dev
+# 2. Install desktop deps (Tauri CLI + React frontend)
+cd desktop && bun install
+
+# 3. Compile the sidecar binary (without this, step 4 fails because externalBin can't find it)
+bun run build:sidecars
+
+# 4. Launch the desktop app in dev mode
+bun run tauri dev
 ```
+
+> **Linux users**: you also need WebKitGTK, libappindicator, librsvg, and friends installed
+> first — see the [Tauri prerequisites guide](https://v2.tauri.app/start/prerequisites/).
+> The maintainer doesn't run Linux day-to-day; PRs adding distro-specific install commands welcome.
 
 ### Configuration
 

--- a/docs/CONTRIBUTING_en.md
+++ b/docs/CONTRIBUTING_en.md
@@ -5,20 +5,26 @@ Thank you for your interest in DreamCoder! Whether you're reporting a bug, sugge
 ## ⚡ 5-Minute Quick Start (TL;DR)
 
 ```bash
-# 1. Fork on GitHub, then clone your fork
+# 1. Fork on GitHub, then clone your fork (Bun >= 1.0, Rust, Node >= 18 required)
 git clone https://github.com/<your-name>/dreamcoder.git && cd dreamcoder
 
-# 2. Install dependencies (Bun >= 1.0, Rust, Node >= 18 required)
+# 2. Install root workspace deps (sidecar runtime)
 bun install
 
-# 3. Start the desktop app in dev mode
-cd desktop && bun run dev
+# 3. Install desktop deps (Tauri CLI + React frontend)
+cd desktop && bun install
 
-# 4. Pick an issue with the `good first issue` or `help wanted` label,
+# 4. Compile the sidecar binary (without this, step 5 fails — externalBin can't find it)
+bun run build:sidecars
+
+# 5. Start the desktop app in dev mode
+bun run tauri dev
+
+# 6. Pick an issue with the `good first issue` or `help wanted` label,
 #    create a feature branch from `dev`
 git checkout dev && git checkout -b feat/your-feature
 
-# 5. Code → bun run lint → bun run test → push → open a PR targeting `dev`
+# 7. Code → bun run lint → bun run test → push → open a PR targeting `dev`
 ```
 
 👉 **First time?** Browse [good first issues](https://github.com/GoDiao/dreamcoder/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). Each one has a mentor — feel free to ping them in the issue or PR.
@@ -119,12 +125,31 @@ dreamcoder/
 # - Bun >= 1.0
 # - Rust (for compiling Tauri)
 # - Node.js >= 18
+# - Linux also needs WebKitGTK, libappindicator, librsvg, etc.
+#   See https://v2.tauri.app/start/prerequisites/
 
 git clone https://github.com/GoDiao/dreamcoder.git
-cd dreamcoder/desktop
+cd dreamcoder
+
+# Step 1: install root workspace deps (sidecar: Anthropic SDK, AWS SDK, ink, etc.)
 bun install
+
+# Step 2: install desktop deps (Tauri CLI + React frontend)
+cd desktop && bun install
+
+# Step 3: compile the sidecar binary
+#   Produces desktop/src-tauri/binaries/dreamcoder-sidecar-<target>
+#   tauri.conf.json's externalBin points at it; step 4 fails to launch without it.
+bun run build:sidecars
+
+# Step 4: launch dev mode
 bun run tauri dev
 ```
+
+> Seeing `failed to find binary 'dreamcoder-sidecar-...'`?
+> 99% chance you skipped Step 3 `bun run build:sidecars`.
+> Seeing `command not found: tauri` or a `@tauri-apps/cli` error?
+> 99% chance you skipped Step 2 `cd desktop && bun install` (Tauri CLI lives in the desktop sub-package; root install won't pull it in).
 
 ## License
 

--- a/docs/CONTRIBUTING_zh.md
+++ b/docs/CONTRIBUTING_zh.md
@@ -5,20 +5,26 @@
 ## ⚡ 5 分钟快速上手 (TL;DR)
 
 ```bash
-# 1. 在 GitHub 上 Fork，然后 clone 你的 fork
+# 1. 在 GitHub 上 Fork，然后 clone 你的 fork（需要 Bun >= 1.0、Rust、Node >= 18）
 git clone https://github.com/<your-name>/dreamcoder.git && cd dreamcoder
 
-# 2. 安装依赖（需要 Bun >= 1.0、Rust、Node >= 18）
+# 2. 装根工作区依赖（sidecar 运行时）
 bun install
 
-# 3. 启动桌面端开发模式
-cd desktop && bun run dev
+# 3. 装桌面端依赖（Tauri CLI + React 前端）
+cd desktop && bun install
 
-# 4. 在 issue 列表挑一个带 `good first issue` 或 `help wanted` 标签的任务，
+# 4. 编译 sidecar 二进制（不跑这步，下一步会因 externalBin 缺失而失败）
+bun run build:sidecars
+
+# 5. 启动桌面端开发模式
+bun run tauri dev
+
+# 6. 在 issue 列表挑一个带 `good first issue` 或 `help wanted` 标签的任务，
 #    从 dev 分支拉一个功能分支
 git checkout dev && git checkout -b feat/your-feature
 
-# 5. 写代码 → bun run lint → bun run test → push → 提 PR 到 dev 分支
+# 7. 写代码 → bun run lint → bun run test → push → 提 PR 到 dev 分支
 ```
 
 👉 **第一次贡献？** 直接看 [good first issues](https://github.com/GoDiao/dreamcoder/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)，每条都有 mentor，可以在 issue 或 PR 里直接 at 他们。
@@ -119,12 +125,31 @@ dreamcoder/
 # - Bun >= 1.0
 # - Rust (用于编译 Tauri)
 # - Node.js >= 18
+# - Linux 还需要 WebKitGTK / libappindicator / librsvg 等系统库
+#   详见 https://v2.tauri.app/start/prerequisites/
 
 git clone https://github.com/GoDiao/dreamcoder.git
-cd dreamcoder/desktop
+cd dreamcoder
+
+# Step 1: 安装根工作区依赖（sidecar：Anthropic SDK / AWS SDK / ink 等）
 bun install
+
+# Step 2: 安装桌面端依赖（Tauri CLI + React 前端）
+cd desktop && bun install
+
+# Step 3: 编译 sidecar 二进制
+#   这一步会产物 desktop/src-tauri/binaries/dreamcoder-sidecar-<target>
+#   tauri.conf.json 里 externalBin 指向它，没有的话 step 4 会启动失败。
+bun run build:sidecars
+
+# Step 4: 启动 dev 模式
 bun run tauri dev
 ```
+
+> 看到 `failed to find binary 'dreamcoder-sidecar-...'`？
+> 99% 是漏跑了 Step 3 `bun run build:sidecars`。
+> 看到 `command not found: tauri` 或 `@tauri-apps/cli` 报错？
+> 99% 是漏跑了 Step 2 `cd desktop && bun install`（Tauri CLI 在 desktop 子包里，根 install 不会装）。
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

- Fix the incorrect 3-step build instructions across all 4 docs files (README × 2, CONTRIBUTING × 2)
- Replace `bun install` + `cd desktop && bun run dev` with the correct **4-step monorepo build sequence**:
  1. `bun install` (root workspace — sidecar runtime deps)
  2. `cd desktop && bun install` (Tauri CLI + frontend deps)
  3. `bun run build:sidecars` (compile sidecar binary — without this `externalBin` fails)
  4. `bun run tauri dev` (launch dev mode)
- Add troubleshooting callouts for the two most common errors
- Add Linux system deps note linking to Tauri prerequisites (no distro-specific commands — unverified)

## Why

Contributors on Linux (#25 — @Kafkacodes, @yayacat) hit build failures because the docs omitted Step 2 (desktop deps) and Step 3 (sidecar binary). The root `bun install` alone doesn't pull in `@tauri-apps/cli` or produce the sidecar binary that `tauri.conf.json`'s `externalBin` expects.

## Files changed

| File | Sections updated |
|------|-----------------|
| `README.md` | 快速开始 → 安装与运行 |
| `README_en.md` | Getting Started → Installation |
| `docs/CONTRIBUTING_zh.md` | 5 分钟快速上手 + 开发环境 |
| `docs/CONTRIBUTING_en.md` | 5-Minute Quick Start + Development Environment |

Refs #25