### PR TITLE
docs: TROUBLESHOOTING guide + perf: fix listSessions memory explosion (#25)

### DIFF
--- a/desktop/scripts/benchmark/mem-monitor.ps1
+++ b/desktop/scripts/benchmark/mem-monitor.ps1
@@ -1,0 +1,86 @@
+# DreamCoder Memory Monitor (non-interactive)
+# Samples every 2 sec, no marker input needed.
+# Output: E:\.cache\tmp\dreamcoder-mem-<timestamp>.csv
+
+param(
+    [int]$IntervalSec = 2,
+    [string]$OutDir = "E:\.cache\tmp",
+    [int]$MaxSamples = 60
+)
+
+$ErrorActionPreference = "Stop"
+
+$WatchNames = @(
+    'dreamcoder-desktop', 'DreamCoder', 'dreamcoder',
+    'msedgewebview2', 'WebView2',
+    'bun', 'node', 'claude', 'claude-code',
+    'dreamcoder-sidecar', 'cargo', 'rustc', 'tauri'
+)
+
+$ts = Get-Date -Format "yyyyMMdd-HHmmss"
+$csvPath = Join-Path $OutDir "dreamcoder-mem-$ts.csv"
+
+if (-not (Test-Path $OutDir)) {
+    New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
+}
+
+"timestamp,elapsed_sec,pid,name,ws_mb,private_mb,cmdline_excerpt" |
+    Out-File -FilePath $csvPath -Encoding utf8
+
+$startTime = Get-Date
+
+Write-Host "[monitor] Started. CSV: $csvPath" -ForegroundColor Cyan
+Write-Host "[monitor] Sampling every ${IntervalSec}s, max $MaxSamples samples." -ForegroundColor Cyan
+
+for ($i = 0; $i -lt $MaxSamples; $i++) {
+    $now = Get-Date
+    $elapsed = [int]($now - $startTime).TotalSeconds
+    $tsStr = $now.ToString("HH:mm:ss")
+
+    $procs = Get-Process -ErrorAction SilentlyContinue |
+        Where-Object {
+            $name = $_.ProcessName
+            ($WatchNames | Where-Object { $name -like "*$_*" })
+        }
+
+    $totalMb = 0.0
+
+    foreach ($p in $procs) {
+        try {
+            $wsMb      = [math]::Round($p.WorkingSet64 / 1MB, 1)
+            $privateMb = [math]::Round($p.PrivateMemorySize64 / 1MB, 1)
+
+            $cmd = ""
+            try {
+                $ci = Get-CimInstance Win32_Process -Filter "ProcessId=$($p.Id)" -ErrorAction SilentlyContinue
+                if ($ci) { $cmd = $ci.CommandLine }
+            } catch {}
+            if ($cmd) {
+                $cmd = $cmd.Replace(",", " ").Replace("`r", " ").Replace("`n", " ")
+                if ($cmd.Length -gt 120) { $cmd = $cmd.Substring(0, 120) + "..." }
+            }
+
+            $totalMb += $privateMb
+
+            $line = "{0},{1},{2},{3},{4},{5},`"{6}`"" -f `
+                $now.ToString("o"), $elapsed, $p.Id, $p.ProcessName, `
+                $wsMb, $privateMb, $cmd
+            Add-Content -Path $csvPath -Value $line -Encoding utf8
+        } catch {}
+    }
+
+    # Top consumers
+    $top = $procs | Sort-Object PrivateMemorySize64 -Descending | Select-Object -First 5
+    $topStr = ($top | ForEach-Object {
+        $ws = [math]::Round($_.WorkingSet64 / 1MB, 1)
+        $priv = [math]::Round($_.PrivateMemorySize64 / 1MB, 1)
+        "$($_.ProcessName):ws=${ws}MB priv=${priv}MB"
+    }) -join " | "
+
+    Write-Host ("[{0}] +{1,3}s  total={2,7:F1} MB  |  {3}" -f `
+        $tsStr, $elapsed, $totalMb, $topStr)
+
+    Start-Sleep -Seconds $IntervalSec
+}
+
+Write-Host "[monitor] Done. CSV: $csvPath" -ForegroundColor Green

--- a/desktop/src/components/layout/AppShell.tsx
+++ b/desktop/src/components/layout/AppShell.tsx
@@ -86,15 +86,20 @@ export function AppShell() {
       }
 
       try {
+        console.log('[mem] AppShell:bootstrap:start')
         await initializeDesktopServerUrl()
+        console.log('[mem] AppShell:after-init-server')
         await fetchSettings()
+        console.log('[mem] AppShell:after-fetch-settings')
 
         if (!cancelled) {
           setReady(true)
         }
 
         void (async () => {
+          console.log('[mem] AppShell:restoreTabs:start')
           await useTabStore.getState().restoreTabs()
+          console.log('[mem] AppShell:restoreTabs:done')
           if (cancelled) return
           const { activeTabId: activeId, tabs } = useTabStore.getState()
           const activeTab = tabs.find((tab) => tab.sessionId === activeId)

--- a/desktop/src/stores/chatStore.ts
+++ b/desktop/src/stores/chatStore.ts
@@ -775,8 +775,13 @@ function mergeSlashCommandUpdates(
 }
 
 async function fetchAndMapSessionHistory(sessionId: string) {
+  const t0 = performance.now()
   const { messages, taskNotifications } = await sessionsApi.getMessages(sessionId)
+  const t1 = performance.now()
+  console.log(`[mem] loadHistory:fetched ${messages.length} msgs in ${(t1-t0).toFixed(0)}ms`)
   const uiMessages = mapHistoryMessagesToUiMessages(messages)
+  const t2 = performance.now()
+  console.log(`[mem] loadHistory:mapped ${uiMessages.length} uiMsgs in ${(t2-t1).toFixed(0)}ms (total ${(t2-t0).toFixed(0)}ms)`)
   const restoredNotifications = {
     ...reconstructAgentNotifications(messages),
     ...agentNotificationRecordFromList(taskNotifications ?? []),
@@ -834,6 +839,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }
 
     get().loadHistory(sessionId)
+    console.log('[mem] connectToSession:loadHistory-called')
     sessionsApi.getSlashCommands(sessionId)
       .then(({ commands }) => {
         if (get().sessions[sessionId]) {

--- a/desktop/src/stores/sessionStore.ts
+++ b/desktop/src/stores/sessionStore.ts
@@ -55,7 +55,9 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   fetchSessions: async (project?: string) => {
     set({ isLoading: true, error: null })
     try {
+      const t0 = performance.now()
       const { sessions: raw } = await sessionsApi.list({ project, limit: 100 })
+      console.log(`[mem] fetchSessions:got ${raw.length} sessions in ${(performance.now()-t0).toFixed(0)}ms`)
       let syncedSessions: SessionListItem[] = []
       set((state) => {
         const currentById = new Map(state.sessions.map((session) => [session.id, session]))

--- a/desktop/src/stores/tabStore.ts
+++ b/desktop/src/stores/tabStore.ts
@@ -5,6 +5,14 @@ import { destroyTerminalRuntime } from '../lib/terminalRuntime'
 
 const TAB_STORAGE_KEY = 'dreamcoder-open-tabs'
 
+// Debug helper for memory profiling during startup
+const memLog = (label: string) => {
+  if (typeof process !== 'undefined' && process.memoryUsage) {
+    const m = process.memoryUsage()
+    console.log(`[mem] ${label}: rss=${(m.rss/1024/1024).toFixed(1)}MB heapUsed=${(m.heapUsed/1024/1024).toFixed(1)}MB heapTotal=${(m.heapTotal/1024/1024).toFixed(1)}MB external=${(m.external/1024/1024).toFixed(1)}MB`)
+  }
+}
+
 export const SETTINGS_TAB_ID = '__settings__'
 export const SCHEDULED_TAB_ID = '__scheduled__'
 export const TERMINAL_TAB_PREFIX = '__terminal__'
@@ -184,7 +192,9 @@ export const useTabStore = create<TabStore>((set, get) => ({
         return
       }
 
+      memLog('restoreTabs:start')
       const { sessions } = await sessionsApi.list({ limit: 200 })
+      memLog(`restoreTabs:after-list (got ${sessions.length} sessions)`)
       const existingIds = new Set(sessions.map((s) => s.id))
 
       const validTabs: Tab[] = data.openTabs

--- a/docs/CONTRIBUTING_en.md
+++ b/docs/CONTRIBUTING_en.md
@@ -150,6 +150,8 @@ bun run tauri dev
 > 99% chance you skipped Step 3 `bun run build:sidecars`.
 > Seeing `command not found: tauri` or a `@tauri-apps/cli` error?
 > 99% chance you skipped Step 2 `cd desktop && bun install` (Tauri CLI lives in the desktop sub-package; root install won't pull it in).
+>
+> More common issues in [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ## License
 

--- a/docs/CONTRIBUTING_zh.md
+++ b/docs/CONTRIBUTING_zh.md
@@ -150,6 +150,8 @@ bun run tauri dev
 > 99% 是漏跑了 Step 3 `bun run build:sidecars`。
 > 看到 `command not found: tauri` 或 `@tauri-apps/cli` 报错？
 > 99% 是漏跑了 Step 2 `cd desktop && bun install`（Tauri CLI 在 desktop 子包里，根 install 不会装）。
+>
+> 更多常见问题见 [TROUBLESHOOTING_zh.md](TROUBLESHOOTING_zh.md)。
 
 ## 许可证
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,108 @@
+# Troubleshooting
+
+Common issues when building or running DreamCoder, and how to fix them.
+
+> **Want to contribute a fix?** See [CONTRIBUTING_en.md](CONTRIBUTING_en.md) for the PR workflow.
+> Issues are tracked at [github.com/GoDiao/dreamcoder/issues](https://github.com/GoDiao/dreamcoder/issues).
+
+---
+
+## Build & Setup
+
+### `failed to find binary 'dreamcoder-sidecar-...'`
+
+**Symptom:** `bun run tauri dev` exits immediately with an error about a missing sidecar binary.
+
+**Cause:** You skipped the `bun run build:sidecars` step. The `desktop/src-tauri/binaries/` directory is gitignored — a fresh clone has no sidecar binary until you compile one.
+
+**Fix:**
+```bash
+cd desktop
+bun run build:sidecars
+bun run tauri dev
+```
+
+---
+
+### `command not found: tauri` or `@tauri-apps/cli` not found
+
+**Symptom:** Running `bun run tauri dev` complains that `tauri` or `@tauri-apps/cli` is missing.
+
+**Cause:** `@tauri-apps/cli` lives in `desktop/package.json`'s `optionalDependencies`. The root `bun install` does **not** install it — you must also run `bun install` inside `desktop/`.
+
+**Fix:**
+```bash
+cd desktop
+bun install
+bun run tauri dev
+```
+
+---
+
+### `dist/` folder not found
+
+**Symptom:** Tauri fails to launch because `desktop/dist/` is missing.
+
+**Cause:** Tauri needs the Vite-built frontend assets. `bun run tauri dev` builds them automatically, but if you're running `cargo tauri` directly or something went wrong with the Vite step, the folder may not exist.
+
+**Fix:**
+```bash
+cd desktop
+bun run build          # produce dist/
+bun run tauri dev
+```
+
+---
+
+### Linux: WebKitGTK / GTK libraries not found
+
+**Symptom:** On Linux, `bun run tauri dev` fails with errors about missing `webkit2gtk`, `libgtk-3`, `libappindicator`, `librsvg`, or similar shared libraries.
+
+**Cause:** Tauri requires several system-level libraries that don't come pre-installed on most Linux distributions.
+
+**Fix:** Install the [Tauri Linux prerequisites](https://v2.tauri.app/start/prerequisites/#linux). Package names vary by distribution:
+
+| Distribution | Command |
+|---|---|
+| Arch Linux | `sudo pacman -S webkit2gtk-4.1 libgtk-3 libappindicator-gtk3 librsvg libsoup3` (community-verified, may need adjustment) |
+| Ubuntu / Debian | See [Tauri docs](https://v2.tauri.app/start/prerequisites/#linux) |
+| Fedora | See [Tauri docs](https://v2.tauri.app/start/prerequisites/#linux) |
+
+> **Note:** The maintainer does not run Linux day-to-day. The Arch command above is a best-effort guess. If you confirm the correct package list for your distro, please open a PR to update this section.
+
+---
+
+## Runtime
+
+### High memory usage (8–16 GB) / UI freeze / OOM kill
+
+**Symptom:** After launching, DreamCoder's sidecar or WebView process grows to 8–16 GB of RAM, causing the UI to freeze or the OS to kill the process (OOM).
+
+**Status:** Under active investigation — tracked in [#25](https://github.com/GoDiao/dreamcoder/issues/25).
+
+**Confirmed on:** Windows 10 x64, Arch Linux.
+
+**Workaround:** None yet. If you can capture a memory profile (e.g., `heapsnapshot` from the sidecar, or your OS's process monitor) and attach it to [#25](https://github.com/GoDiao/dreamcoder/issues/25), that helps a lot.
+
+---
+
+### App launches but UI is blank / white screen
+
+**Symptom:** The Tauri window opens but shows a blank white page.
+
+**Cause:** Usually a Vite dev-server connection issue — the frontend dev server may not have started, or the port is blocked.
+
+**Fix:**
+1. Check that `bun run tauri dev` (not `bun run dev`) was used — `bun run dev` only starts Vite, not Tauri.
+2. Try a production build instead: `cd desktop && bun run build && bun run tauri dev`.
+3. Check the Tauri devtools console (right-click → Inspect) for errors.
+
+---
+
+## Contributing to this Guide
+
+This file is community-maintained. If you hit a problem not listed here and figure out the fix:
+
+1. Open an issue describing the problem and solution.
+2. Once confirmed, open a PR adding your entry to this file.
+3. Follow the format: **Symptom → Cause → Fix → (optional) Notes**.

--- a/docs/TROUBLESHOOTING_zh.md
+++ b/docs/TROUBLESHOOTING_zh.md
@@ -1,0 +1,108 @@
+# 常见问题排查
+
+构建或运行 DreamCoder 时的常见问题及解决方法。
+
+> **想贡献解决方案？** 先看 [CONTRIBUTING_zh.md](CONTRIBUTING_zh.md) 了解 PR 流程。
+> 问题跟踪在 [github.com/GoDiao/dreamcoder/issues](https://github.com/GoDiao/dreamcoder/issues)。
+
+---
+
+## 构建与安装
+
+### `failed to find binary 'dreamcoder-sidecar-...'`
+
+**现象：** `bun run tauri dev` 启动即报错，提示找不到 sidecar 二进制文件。
+
+**原因：** 漏跑了 `bun run build:sidecars`。`desktop/src-tauri/binaries/` 目录在 `.gitignore` 里，全新 clone 的仓库没有 sidecar 二进制，必须手动编译。
+
+**解决：**
+```bash
+cd desktop
+bun run build:sidecars
+bun run tauri dev
+```
+
+---
+
+### `command not found: tauri` 或 `@tauri-apps/cli` 找不到
+
+**现象：** 运行 `bun run tauri dev` 提示 `tauri` 命令不存在。
+
+**原因：** `@tauri-apps/cli` 在 `desktop/package.json` 的 `optionalDependencies` 里，根目录的 `bun install` **不会**安装它，必须在 `desktop/` 里再跑一次 `bun install`。
+
+**解决：**
+```bash
+cd desktop
+bun install
+bun run tauri dev
+```
+
+---
+
+### `dist/` 目录不存在
+
+**现象：** Tauri 启动失败，提示找不到 `desktop/dist/`。
+
+**原因：** Tauri 需要 Vite 构建产物。`bun run tauri dev` 通常会自动构建，但如果直接调 `cargo tauri` 或 Vite 步骤出错，dist 可能缺失。
+
+**解决：**
+```bash
+cd desktop
+bun run build          # 生成 dist/
+bun run tauri dev
+```
+
+---
+
+### Linux：找不到 WebKitGTK / GTK 库
+
+**现象：** Linux 下 `bun run tauri dev` 报错，提示缺少 `webkit2gtk`、`libgtk-3`、`libappindicator`、`librsvg` 等动态库。
+
+**原因：** Tauri 依赖多个系统级库，大多数 Linux 发行版不会预装。
+
+**解决：** 安装 [Tauri Linux 系统依赖](https://v2.tauri.app/start/prerequisites/#linux)。不同发行版的包名不同：
+
+| 发行版 | 安装命令 |
+|---|---|
+| Arch Linux | `sudo pacman -S webkit2gtk-4.1 libgtk-3 libappindicator-gtk3 librsvg libsoup3`（社区验证，可能需要调整） |
+| Ubuntu / Debian | 见 [Tauri 官方文档](https://v2.tauri.app/start/prerequisites/#linux) |
+| Fedora | 见 [Tauri 官方文档](https://v2.tauri.app/start/prerequisites/#linux) |
+
+> **注意：** 维护者不在 Linux 上日常使用，上述 Arch 命令为推测。如果你确认了某发行版的正确包列表，欢迎 PR 更新此节。
+
+---
+
+## 运行时
+
+### 内存占用过高（8–16 GB）/ UI 卡死 / 系统 OOM
+
+**现象：** 启动后，DreamCoder 的 sidecar 或 WebView 进程内存飙升至 8–16 GB，导致 UI 卡死或系统杀进程（OOM）。
+
+**状态：** 正在调查中 —— 跟踪 issue [#25](https://github.com/GoDiao/dreamcoder/issues/25)。
+
+**已确认平台：** Windows 10 x64、Arch Linux。
+
+**临时方案：** 暂无。如果你能抓取内存快照（如 sidecar 的 `heapsnapshot` 或系统进程监控数据）贴到 [#25](https://github.com/GoDiao/dreamcoder/issues/25)，会很有帮助。
+
+---
+
+### 窗口打开了但页面白屏
+
+**现象：** Tauri 窗口打开了，但显示空白页面。
+
+**原因：** 通常是 Vite 开发服务器连接问题 —— 前端 dev server 没启动或端口被占用。
+
+**解决：**
+1. 确认用的是 `bun run tauri dev` 而不是 `bun run dev`（后者只启动 Vite，不启动 Tauri）。
+2. 尝试 production 构建：`cd desktop && bun run build && bun run tauri dev`。
+3. 打开 Tauri 开发者工具（右键 → Inspect）查看控制台报错。
+
+---
+
+## 参与维护本指南
+
+本文件由社区共同维护。如果你遇到了这里没列出的问题并找到了解决方案：
+
+1. 先开 issue 描述问题和解决方法。
+2. 确认后，提 PR 将你的条目加入本文件。
+3. 格式参照现有条目：**现象 → 原因 → 解决 → （可选）备注**。

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -391,6 +391,8 @@ export function startServer(port = PORT, host = HOST) {
     )
   })
 
+  const mem = process.memoryUsage()
+  console.log(`[mem:sidecar] server:startup rss=${(mem.rss/1024/1024).toFixed(1)}MB heapUsed=${(mem.heapUsed/1024/1024).toFixed(1)}MB`)
   console.log(`[Server] Claude Code API server running at http://${host}:${port}`)
   return server
 }

--- a/src/server/services/sessionService.ts
+++ b/src/server/services/sessionService.ts
@@ -6,8 +6,10 @@
  */
 
 import * as fs from 'node:fs/promises'
+import * as fsSync from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
+import * as readline from 'node:readline'
 import { ApiError } from '../middleware/errorHandler.js'
 import { sanitizePath as sanitizePortablePath } from '../../utils/sessionStoragePortable.js'
 import type { FileHistorySnapshot } from '../../utils/fileHistory.js'
@@ -279,6 +281,72 @@ export class SessionService {
       }
     }
     return entries
+  }
+
+  /**
+   * Stream a session file once to extract head+tail entries and count transcript
+   * messages. Never loads the full file into memory — peak memory is O(headLines).
+   */
+  private scanSessionFileHead(
+    filePath: string,
+    headLines: number,
+    tailLines: number,
+  ): Promise<{ entries: RawEntry[]; messageCount: number }> {
+    return new Promise((resolve, reject) => {
+      const head: string[] = []
+      const tailRing: string[] = new Array(tailLines)
+      let lineCount = 0
+      let messageCount = 0
+
+      const stream = fsSync.createReadStream(filePath, { encoding: 'utf-8' })
+      const rl = readline.createInterface({ input: stream, crlfDelay: Infinity })
+
+      rl.on('line', (line) => {
+        const trimmed = line.trim()
+        if (!trimmed) return
+
+        // Head capture
+        if (lineCount < headLines) {
+          head.push(trimmed)
+        }
+        // Ring buffer for tail
+        tailRing[lineCount % tailLines] = trimmed
+        lineCount++
+
+        // Fast string match for transcript counting
+        if (
+          (trimmed.includes('"type":"user"') || trimmed.includes('"type":"assistant"')) &&
+          trimmed.includes('"role"')
+        ) {
+          messageCount++
+        }
+      })
+
+      rl.on('close', () => {
+        // Reconstruct tail in order from ring buffer
+        const tailStart = Math.max(0, lineCount - tailLines)
+        const orderedTail: string[] = []
+        for (let i = tailStart; i < lineCount; i++) {
+          const entry = tailRing[i % tailLines]
+          if (entry) orderedTail.push(entry)
+        }
+
+        const selected = [...head, ...orderedTail]
+        const entries: RawEntry[] = []
+        for (const line of selected) {
+          try { entries.push(JSON.parse(line) as RawEntry) } catch { /* skip malformed */ }
+        }
+        resolve({ entries, messageCount })
+      })
+
+      rl.on('error', (err) => {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          resolve({ entries: [], messageCount: 0 })
+        } else {
+          reject(err)
+        }
+      })
+    })
   }
 
   private async appendJsonlEntry(filePath: string, entry: Record<string, unknown>): Promise<void> {
@@ -1284,6 +1352,8 @@ export class SessionService {
     limit?: number
     offset?: number
   }): Promise<{ sessions: SessionListItem[]; total: number }> {
+    const mem0 = process.memoryUsage()
+    console.log(`[mem:sidecar] listSessions:start rss=${(mem0.rss/1024/1024).toFixed(1)}MB heapUsed=${(mem0.heapUsed/1024/1024).toFixed(1)}MB`)
     const sessionFiles = await this.discoverSessionFiles(options?.project)
     const filesWithStats = (await Promise.all(sessionFiles.map(async (sessionFile) => {
       try {
@@ -1303,24 +1373,19 @@ export class SessionService {
     const limit = options?.limit ?? 50
     const paginatedFiles = filesWithStats.slice(offset, offset + limit)
 
-    // Build session list items with metadata from file stats & first entries
+    // Build session list items with metadata from file head/tail only (avoid loading full files)
     const items = (await Promise.all(paginatedFiles.map(async ({ filePath, projectDir, sessionId, stat }) => {
       try {
-        const entries = await this.readJsonlFile(filePath)
-        const workDir = this.resolveWorkDirFromEntries(entries, projectDir)
-        const projectRoot = await this.resolveProjectRootFromEntries(entries, workDir, projectDir)
+        const { entries: headEntries, messageCount } = await this.scanSessionFileHead(filePath, 100, 100)
+        const workDir = this.resolveWorkDirFromEntries(headEntries, projectDir)
+        const projectRoot = await this.resolveProjectRootFromEntries(headEntries, workDir, projectDir)
         const workDirExists = await this.pathExists(workDir)
 
-        // Count transcript messages only (user + assistant)
-        const messageCount = entries.filter(
-          (e) => (e.type === 'user' || e.type === 'assistant') && e.message?.role
-        ).length
+        const title = this.extractTitle(headEntries)
 
-        const title = this.extractTitle(entries)
-
-        // Find the earliest timestamp from entries, fallback to file birthtime
+        // Find the earliest timestamp from head entries, fallback to file birthtime
         let createdAt = stat.birthtime.toISOString()
-        for (const e of entries) {
+        for (const e of headEntries) {
           if (e.timestamp) {
             createdAt = e.timestamp
             break
@@ -1344,6 +1409,8 @@ export class SessionService {
       }
     }))).filter((item): item is SessionListItem => item !== null)
 
+    const mem1 = process.memoryUsage()
+    console.log(`[mem:sidecar] listSessions:done total=${total} returned=${items.length} rss=${(mem1.rss/1024/1024).toFixed(1)}MB heapUsed=${(mem1.heapUsed/1024/1024).toFixed(1)}MB`)
     return { sessions: items, total }
   }
 
@@ -1394,17 +1461,21 @@ export class SessionService {
    * Get only the messages for a session (lighter than full detail).
    */
   async getSessionMessages(sessionId: string): Promise<MessageEntry[]> {
+    const mem0 = process.memoryUsage()
     const found = await this.findSessionFile(sessionId)
     if (!found) {
       throw ApiError.notFound(`Session not found: ${sessionId}`)
     }
 
     const entries = await this.readJsonlFile(found.filePath)
-    return await this.appendSubagentToolMessages(
+    const messages = await this.appendSubagentToolMessages(
       found.projectDir,
       sessionId,
       this.entriesToMessages(entries),
     )
+    const mem1 = process.memoryUsage()
+    console.log(`[mem:sidecar] getSessionMessages:done session=${sessionId} entries=${entries.length} msgs=${messages.length} rss=${(mem1.rss/1024/1024).toFixed(1)}MB heapUsed=${(mem1.heapUsed/1024/1024).toFixed(1)}MB (delta rss=${((mem1.rss-mem0.rss)/1024/1024).toFixed(1)}MB)`)
+    return messages
   }
 
   /**


### PR DESCRIPTION
## Changes

### 1. TROUBLESHOOTING guide (docs)
New community-maintained troubleshooting guide (`docs/TROUBLESHOOTING.md` + `docs/TROUBLESHOOTING_zh.md`) covering:
- Build: missing sidecar binary, missing Tauri CLI, missing dist/, Linux system deps
- Runtime: high memory / OOM (#25), blank white screen
- CONTRIBUTING now links to TROUBLESHOOTING

### 2. Fix listSessions memory explosion (perf)
`listSessions` was loading every session's full JSONL file into memory just to extract 5 metadata fields. With 48 sessions this consumed ~2 GB RSS per call.

Replaced with `scanSessionFileHead`: a single `readline` stream pass that captures head+tail lines and counts messages via string match. Peak memory is O(headLines) instead of O(fileSize).

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| `listSessions` RSS delta | +1960 MB | +351 MB | **-82%** |
| `listSessions` heapUsed | 811 MB | 69 MB | **-91%** |
| sidecar peak RSS | 2499 MB | 923 MB | **-63%** |
| sidecar steady-state | 1300-1900 MB | 790-920 MB | **-50%** |

### 3. Memory profiling tooling
- `[mem:sidecar]` / `[mem]` console logs at key startup points
- `desktop/scripts/benchmark/mem-monitor.ps1` for external process monitoring

## Credit
- TROUBLESHOOTING idea from @Kafkacodes in #25
- Memory data from @yayacat (Windows 16GB WebView2) confirming cross-platform

Refs #25