### PR TITLE
Refine README copy and stabilize chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,19 @@
 
 ---
 
+<div align="right">
+
+[English](./README_en.md) | 简体中文
+
+</div>
+
 <div align="center">
 
 # DreamCoder
 
-**Claude Code 的开源桌面版 GUI**
+**Claude Code 的开源桌面端图形界面**
 
-*面向创造者的 AI 编程工作台*
+*更适合日常创作与协作的 AI 编程工作台*
 
 [![Tauri 2](https://img.shields.io/badge/Tauri-2-blue)](https://v2.tauri.app/)
 [![React 18](https://img.shields.io/badge/React-18-61DAFB)](https://react.dev/)
@@ -43,48 +49,48 @@
 
 ---
 
-## ✨ 为什么是 DreamCoder？
+## ✨ 为什么选择 DreamCoder？
 
-Claude Code 非常强大，但它是一个纯命令行工具 (CLI-only)。
-**DreamCoder 将 Claude Code 强大的核心引擎，封装进了现代的原生桌面应用中。**
+Claude Code 的能力很强，但命令行并不适合所有人。
+**DreamCoder 把 Claude Code 的核心能力带进原生桌面应用，让会话管理、模型切换、文件操作都更直观。**
 
-> “我想要 Claude Code 的能力，但我需要一个 GUI 来管理会话、切换模型、处理文件。”
+> “我想要 Claude Code 的能力，也想要一个顺手的桌面界面来管理会话、切换模型、处理文件。”
 
-*   **非叉子 (Not a Fork)**：DreamCoder 复用了 Claude Code 的核心逻辑，或使用兼容的运行时。它只是给命令行体验穿上了一件漂亮的外衣。
-*   **隐私优先**：你的 API Key 和数据完全保存在本地。不依赖任何云端服务。
-*   **全模型支持**：无缝切换 Anthropic, OpenAI, DeepSeek, 阿里通义、MiniMax, Azure, Google Vertex 等。
+*   **基于 Claude Code 核心体验演进**：DreamCoder 复用了 Claude Code 的核心逻辑，或使用兼容运行时，在保留能力边界的同时补上桌面交互体验。
+*   **隐私优先**：API Key 与数据默认保存在本地，不依赖托管云端服务。
+*   **多模型自由切换**：无缝接入 Anthropic、OpenAI、DeepSeek、阿里通义、MiniMax、Azure、Google Vertex 等。
 
 ---
 
 ## 🚀 核心功能
 
 ### 1. 原生桌面体验
-*   **会话管理**：可视化历史、侧边栏导航、多标签页界面。
-*   **集成终端**：内置 PTY (PowerShell/Bash/Zsh)，集成 xterm.js。
-*   **可视化设置**：告别手动编辑 JSON 文件，在 UI 上直接管理 Provider 和 API Key。
+*   **会话管理更顺手**：可视化历史、侧边栏导航、多标签页界面。
+*   **终端无缝融入工作流**：内置 PTY (PowerShell/Bash/Zsh)，集成 xterm.js。
+*   **设置项可视化**：无需手动编辑 JSON，直接在 UI 中管理 Provider 和 API Key。
 
 ![主界面](./assets/main.png)
 
-### 2. 完美对接 Claude Code
-*   **Computer Use 模式**：原生支持视觉模型控制电脑（截图模式），以及全新的 **UIA Tree 模式**（文本辅助访问模式，更快、更低成本）。
-*   **工具调用可视化**：AI 读写文件、执行终端命令的过程全程透明可见。
-*   **MCP 支持**：通过 Model Context Protocol 扩展 AI 能力。
+### 2. 深度适配 Claude Code
+*   **Computer Use 双模式**：同时支持视觉截图模式，以及全新的 **UIA Tree 模式**（文本辅助访问，更快、成本更低）。
+*   **工具调用全程可见**：AI 读写文件、执行终端命令的过程透明呈现，便于理解与审查。
+*   **MCP 扩展能力**：通过 Model Context Protocol 持续扩展 AI 的上下文与工具能力。
 
 ![Computer Use 设置](./assets/setting_computeruse.png)
 
-### 3. 高级 Provider 系统
-*   **一键切换**：点击即可在不同模型供应商之间切换。
-*   **支持列表**：Anthropic (Claude), OpenAI, DeepSeek, Moonshot (Kimi), MiniMax, Azure OpenAI, Google Vertex, AWS Bedrock。
-*   **可视化测试**：在设置界面直接测试连接状态和延迟。
+### 3. 灵活的 Provider 体系
+*   **切换足够轻**：点击即可在不同模型供应商之间切换。
+*   **支持范围够广**：Anthropic (Claude)、OpenAI、DeepSeek、Moonshot (Kimi)、MiniMax、Azure OpenAI、Google Vertex、AWS Bedrock。
+*   **连接状态一眼可见**：可在设置界面直接测试可用性与延迟。
 
 ![Provider 设置](./assets/setting_provider.png)
 
 ---
 
 ### 4. MCP 扩展
-*   **MCP 原生支持**：Model Context Protocol 全面支持。
-*   **可视化配置**：告别 JSON 配置，图形界面管理 MCP 服务器。
-*   **开箱即用**：内置常用 MCP 工具集成。
+*   **原生支持 MCP**：完整接入 Model Context Protocol。
+*   **配置过程图形化**：不再手写 JSON，通过界面管理 MCP 服务器。
+*   **开箱即可扩展**：内置常用 MCP 工具集成，方便快速接入。
 
 ![MCP 技能设置](./assets/setting_skills.png)
 
@@ -107,14 +113,15 @@ Claude Code 非常强大，但它是一个纯命令行工具 (CLI-only)。
 
 | 平台          | 状态                                          | 预编译安装包                                          |
 |---------------|-----------------------------------------------|-------------------------------------------------------|
-| Windows x64   | ✅ 维护者实测                                  | ✅ NSIS `.exe` + MSI `.msi`（每个 release 都发）       |
-| macOS arm64   | ⚠️ 维护者**未实测**（仅留有构建脚本）           | ❌ 等社区帮忙                                          |
-| Linux x64     | ⚠️ 维护者**未实测**                            | ❌ 等社区帮忙                                          |
+| Windows x64   | ✅ 维护者长期实测                              | ✅ NSIS `.exe` + MSI `.msi`（每个 release 都提供）     |
+| macOS arm64   | ⚠️ 暂未日常验证（已保留构建脚本）               | ❌ 欢迎社区共同补齐                                    |
+| Linux x64     | ⚠️ 暂未日常验证                                | ❌ 欢迎社区共同补齐                                    |
 
-> DreamCoder 当前**仅在 Windows x64 上开发与验证**。代码里有 `#[cfg(target_os = "macos" / "linux")]`
-> 分支，但维护者本人日常不在这两个平台上跑，所以非 Windows 构建处于"理论 cover、实测未知"的状态。
-> 如果你是 macOS / Linux 用户，bug 报告和 PR 都非常欢迎 ——
-> Linux 内存问题正在 [#25](https://github.com/GoDiao/dreamcoder/issues/25) 调查中。
+> DreamCoder 当前主要围绕 **Windows x64** 持续开发和验证。
+> 代码中已经保留 `#[cfg(target_os = "macos" / "linux")]` 分支，但由于维护者并不日常使用这两个平台，
+> 非 Windows 构建目前仍属于“代码已覆盖、体验待更多实机验证”的状态。
+> 如果你正在使用 macOS 或 Linux，欢迎通过 issue 或 PR 一起把这部分体验补完整；
+> Linux 内存问题可关注 [#25](https://github.com/GoDiao/dreamcoder/issues/25)。
 
 ---
 
@@ -135,12 +142,12 @@ Claude Code 非常强大，但它是一个纯命令行工具 (CLI-only)。
 
 ### 环境要求
 *   [Bun](https://bun.sh/) >= 1.0
-*   [Rust](https://www.rust-lang.org/tools/install) (用于编译桌面端)
-*   Node.js >= 18 (部分依赖需要)
+*   [Rust](https://www.rust-lang.org/tools/install)（用于构建桌面端）
+*   Node.js >= 18（部分依赖仍会用到）
 
 ### 安装与运行
 
-> 这是一个 Bun monorepo（根 + `desktop/` 各有独立 `package.json`），**四步都不能跳**，否则 `tauri dev` 会因为缺 sidecar 二进制 / Tauri CLI 启动失败。
+> 这是一个 Bun monorepo（根目录与 `desktop/` 各自维护依赖）。**下面四步建议完整执行**，否则 `tauri dev` 往往会因为 sidecar 二进制或 Tauri CLI 缺失而无法启动。
 
 ```bash
 # 0. 克隆仓库
@@ -153,32 +160,32 @@ bun install
 # 2. 安装桌面端依赖（Tauri CLI + React 前端）
 cd desktop && bun install
 
-# 3. 编译 sidecar 二进制（不跑这步，第 4 步会因 externalBin 缺失而失败）
+# 3. 编译 sidecar 二进制
 bun run build:sidecars
 
 # 4. 启动桌面端开发模式
 bun run tauri dev
 ```
 
-> **Linux 用户**：还需要先装好 WebKitGTK / libappindicator / librsvg 等系统库，
+> **Linux 用户**：还需要先安装 WebKitGTK、libappindicator、librsvg 等系统依赖，
 > 详见 [Tauri 官方 prerequisites](https://v2.tauri.app/start/prerequisites/)。
-> 维护者不在 Linux 上日常使用，欢迎 PR 补充发行版具体命令。
+> 如果你愿意补充发行版对应命令，欢迎直接提交 PR。
 
 ### 配置 AI 模型
 
-1.  打开 DreamCoder，进入 **设置 -> Provider (模型供应商)**。
-2.  添加你的 API Key (例如：Anthropic, OpenAI, 或 DeepSeek)。
-3.  选择默认模型，即可开始编程。
+1. 打开 DreamCoder，进入 **设置 -> Provider（模型供应商）**。
+2. 添加你的 API Key（例如 Anthropic、OpenAI 或 DeepSeek）。
+3. 选择默认模型后即可开始使用。
 
 ---
 
 ## 🤝 贡献指南
 
-欢迎提交 Issue 和 PR！请阅读我们的 [贡献指南](docs/CONTRIBUTING_zh.md) 了解更多详情。
+欢迎提交 Issue 和 PR。若你准备参与改进 DreamCoder，建议先阅读 [贡献指南](docs/CONTRIBUTING_zh.md)，可以更快熟悉开发流程与协作方式。
 
 ## 📝 更新日志
 
-版本历史详见 [CHANGELOG.md](CHANGELOG.md)。
+版本演进与重要变更见 [CHANGELOG.md](CHANGELOG.md)。
 
 ## 📄 许可证
 

--- a/README_en.md
+++ b/README_en.md
@@ -4,13 +4,19 @@
 ╚══════════════════════════════════════════════════════════════════════════╝
 -->
 
+<div align="right">
+
+English | [简体中文](./README.md)
+
+</div>
+
 <div align="center">
 
 # DreamCoder
 
-**The Open-Source Desktop GUI for Claude Code**
+**An open-source desktop GUI for Claude Code**
 
-*A full-featured AI coding workbench that combines the power of Claude Code with a modern native desktop experience.*
+*A polished AI coding workspace built for everyday creation and collaboration.*
 
 [![Tauri 2](https://img.shields.io/badge/Tauri-2-blue)](https://v2.tauri.app/)
 [![React 18](https://img.shields.io/badge/React-18-61DAFB)](https://react.dev/)
@@ -27,33 +33,33 @@
 
 ## ✨ Why DreamCoder?
 
-Claude Code is powerful, but it's CLI-only.
-DreamCoder brings a **native desktop interface** to that powerful engine.
+Claude Code is powerful, but the command line is not the best interface for every workflow.
+**DreamCoder brings Claude Code's core capabilities into a native desktop app, making session management, model switching, and file operations far more intuitive.**
 
-> "I want the power of Claude Code, but I need a GUI for session management, provider switching, and visual interaction."
+> "I want the power of Claude Code, plus a desktop interface that makes sessions, models, and files easier to manage."
 
-*   **Not a Fork**: DreamCoder runs alongside Claude Code logic (or replaces it with compatible runtimes). It wraps the CLI experience in a beautiful, usable window.
-*   **Privacy First**: Your API keys and data stay on your machine. No cloud dependency required.
-*   **Universal Provider**: Seamlessly switch between Anthropic, OpenAI, DeepSeek, Azure, Google Vertex, and more.
+*   **Built on the Claude Code experience**: DreamCoder reuses Claude Code's core logic, or a compatible runtime, and adds the desktop interaction layer that many daily workflows need.
+*   **Privacy first**: API keys and data stay on your machine by default, with no hosted cloud dependency required.
+*   **Freedom across providers**: Seamlessly switch between Anthropic, OpenAI, DeepSeek, Azure, Google Vertex, and more.
 
 ---
 
 ## 🚀 Key Features
 
 ### 1. Native Desktop Experience
-*   **Session Management**: Visual history, sidebar navigation, and tabbed interface.
-*   **Integrated Terminal**: Built-in PTY (PowerShell/Bash/Zsh) with xterm.js.
-*   **Settings GUI**: Manage providers, API keys, and preferences without editing JSON files.
+*   **Smoother session management**: Visual history, sidebar navigation, and a tabbed interface.
+*   **Terminal built into the workflow**: Built-in PTY (PowerShell/Bash/Zsh) with xterm.js.
+*   **Settings you can manage visually**: Configure providers, API keys, and preferences without editing JSON files.
 
-### 2. Claude Code Compatibility
-*   **Computer Use Mode**: Native support for visual AI control (screenshots) AND the new **UIA Tree mode** (text-only accessibility, faster, lower cost).
-*   **Tool Execution**: Fully transparent file editing and command execution.
-*   **MCP Support**: Extend AI capabilities with the Model Context Protocol.
+### 2. Deep Claude Code Integration
+*   **Dual Computer Use modes**: Supports both visual screenshot control and the new **UIA Tree mode** (text-based accessibility, faster and more cost-efficient).
+*   **Transparent tool execution**: File edits and terminal commands are surfaced clearly, so it's easy to understand and review what the agent is doing.
+*   **MCP extensibility**: Expand context and tooling through the Model Context Protocol.
 
-### 3. Advanced Provider System
-*   One-click switching between multiple LLM providers.
-*   **Supported**: Anthropic (Claude), OpenAI, DeepSeek, Moonshot (Kimi), MiniMax, Azure OpenAI, Google Vertex, AWS Bedrock.
-*   **Visual Testing**: Test connectivity and latency directly in the settings UI.
+### 3. Flexible Provider Layer
+*   **Switch providers in one click**: Move between model vendors without friction.
+*   **Broad model coverage**: Anthropic (Claude), OpenAI, DeepSeek, Moonshot (Kimi), MiniMax, Azure OpenAI, Google Vertex, AWS Bedrock.
+*   **Connectivity visible at a glance**: Test availability and latency directly from Settings.
 
 ---
 
@@ -74,15 +80,15 @@ DreamCoder brings a **native desktop interface** to that powerful engine.
 
 | Platform     | Status                                  | Pre-built Installer                                      |
 |--------------|-----------------------------------------|----------------------------------------------------------|
-| Windows x64  | ✅ Tested by maintainer                  | ✅ NSIS `.exe` + MSI `.msi` (every release)               |
-| macOS arm64  | ⚠️ Untested by maintainer (build script exists) | ❌ Community help wanted                            |
-| Linux x64    | ⚠️ Untested by maintainer                | ❌ Community help wanted                                  |
+| Windows x64  | ✅ Maintainer-tested regularly           | ✅ NSIS `.exe` + MSI `.msi` (published with each release) |
+| macOS arm64  | ⚠️ Not part of daily validation yet      | ❌ Community help welcome                                 |
+| Linux x64    | ⚠️ Not part of daily validation yet      | ❌ Community help welcome                                 |
 
-> DreamCoder is currently developed and verified on **Windows x64**. The codebase includes
-> `#[cfg(target_os = "macos" / "linux")]` branches but the maintainer does not run those
-> platforms day-to-day, so non-Windows builds are best-effort. If you're a macOS/Linux user,
-> bug reports and PRs are extremely welcome — see [#25](https://github.com/GoDiao/dreamcoder/issues/25)
-> for the current Linux investigation.
+> DreamCoder is developed and validated primarily on **Windows x64**.
+> The codebase already includes `#[cfg(target_os = "macos" / "linux")]` branches, but those platforms
+> are not part of the maintainer's day-to-day workflow yet, so non-Windows support is still best-effort.
+> If you're running DreamCoder on macOS or Linux, issues and PRs are especially valuable;
+> for the current Linux memory investigation, see [#25](https://github.com/GoDiao/dreamcoder/issues/25).
 
 ---
 
@@ -103,50 +109,50 @@ See [ROADMAP](docs/ROADMAP_en.md)
 
 ### Prerequisites
 *   [Bun](https://bun.sh/) >= 1.0
-*   [Rust](https://www.rust-lang.org/tools/install) (for building the desktop app)
-*   Node.js >= 18 (for some dependencies)
+*   [Rust](https://www.rust-lang.org/tools/install) (required to build the desktop app)
+*   Node.js >= 18 (still needed by parts of the dependency chain)
 
 ### Installation
 
-> This is a Bun monorepo (root + `desktop/` each have their own `package.json`). **All four steps are required** — skipping any one breaks `tauri dev` (missing sidecar binary or missing Tauri CLI).
+> This is a Bun monorepo, with separate dependencies at the repo root and in `desktop/`. **Run all four steps below** to avoid startup failures in `tauri dev`, especially around the sidecar binary or missing Tauri CLI pieces.
 
 ```bash
 # 0. Clone the repo
 git clone https://github.com/GoDiao/dreamcoder.git
 cd dreamcoder
 
-# 1. Install root workspace deps (sidecar runtime — Anthropic SDK, AWS SDK, ink, etc.)
+# 1. Install root workspace dependencies (sidecar runtime: Anthropic SDK, AWS SDK, ink, etc.)
 bun install
 
-# 2. Install desktop deps (Tauri CLI + React frontend)
+# 2. Install desktop dependencies (Tauri CLI + React frontend)
 cd desktop && bun install
 
-# 3. Compile the sidecar binary (without this, step 4 fails because externalBin can't find it)
+# 3. Build the sidecar binary
 bun run build:sidecars
 
 # 4. Launch the desktop app in dev mode
 bun run tauri dev
 ```
 
-> **Linux users**: you also need WebKitGTK, libappindicator, librsvg, and friends installed
-> first — see the [Tauri prerequisites guide](https://v2.tauri.app/start/prerequisites/).
-> The maintainer doesn't run Linux day-to-day; PRs adding distro-specific install commands welcome.
+> **Linux users**: you will also need system packages such as WebKitGTK, libappindicator, and librsvg.
+> See the [Tauri prerequisites guide](https://v2.tauri.app/start/prerequisites/) for details.
+> If you can contribute distro-specific setup commands, a PR would be greatly appreciated.
 
-### Configuration
+### Configure Your Model
 
-1.  Open DreamCoder and go to **Settings -> Providers**.
-2.  Add your API Key (e.g., for Anthropic, OpenAI, or DeepSeek).
-3.  Select the default model and start coding.
+1. Open DreamCoder and go to **Settings -> Providers**.
+2. Add your API key (for example Anthropic, OpenAI, or DeepSeek).
+3. Choose a default model and start coding.
 
 ---
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please read our [Contributing Guide](docs/CONTRIBUTING_en.md) for details.
+Issues and pull requests are welcome. If you'd like to improve DreamCoder, start with the [Contributing Guide](docs/CONTRIBUTING_en.md) to get familiar with the workflow and collaboration style.
 
 ## 📝 Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for version history.
+For release history and notable updates, see [CHANGELOG.md](CHANGELOG.md).
 
 ## 📄 License
 

--- a/desktop/scripts/benchmark/mem-compare.ps1
+++ b/desktop/scripts/benchmark/mem-compare.ps1
@@ -1,0 +1,143 @@
+# DreamCoder Memory Before/After Comparator
+#
+# Usage:
+#   .\mem-compare.ps1 -Before path\to\before.csv -After path\to\after.csv
+#
+# Reads two CSVs produced by mem-monitor.ps1 and prints:
+#   - Peak private memory per process (before vs after, delta, % change)
+#   - Average private memory per process
+#   - Total peak comparison
+#
+# Example:
+#   .\mem-compare.ps1 `
+#     -Before E:\.cache\tmp\dreamcoder-mem-before-lru-20260101-120000.csv `
+#     -After  E:\.cache\tmp\dreamcoder-mem-after-lru-20260101-130000.csv
+
+param(
+    [Parameter(Mandatory)][string]$Before,
+    [Parameter(Mandatory)][string]$After,
+    [string]$OutReport = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Read-MemCsv([string]$path) {
+    if (-not (Test-Path $path)) {
+        throw "File not found: $path"
+    }
+    $rows = Import-Csv -Path $path -Encoding utf8
+    # Group by process name, compute peak and average private_mb
+    $byName = @{}
+    foreach ($row in $rows) {
+        $name = $row.name
+        $priv = [double]$row.private_mb
+        if (-not $byName.ContainsKey($name)) {
+            $byName[$name] = @{ peak = $priv; sum = $priv; count = 1 }
+        } else {
+            if ($priv -gt $byName[$name].peak) { $byName[$name].peak = $priv }
+            $byName[$name].sum   += $priv
+            $byName[$name].count += 1
+        }
+    }
+    return $byName
+}
+
+function Format-Delta([double]$before, [double]$after) {
+    $delta = $after - $before
+    $pct   = if ($before -gt 0) { ($delta / $before) * 100 } else { 0 }
+    $sign  = if ($delta -ge 0) { "+" } else { "" }
+    $color = if ($delta -le -10) { "Green" } elseif ($delta -ge 10) { "Red" } else { "White" }
+    return @{
+        text  = "{0}{1:F1} MB ({2}{3:F1}%)" -f $sign, $delta, $sign, $pct
+        color = $color
+    }
+}
+
+Write-Host ""
+Write-Host "=== DreamCoder Memory Comparison ===" -ForegroundColor Cyan
+Write-Host "  Before : $Before" -ForegroundColor DarkGray
+Write-Host "  After  : $After"  -ForegroundColor DarkGray
+Write-Host ""
+
+$bData = Read-MemCsv $Before
+$aData = Read-MemCsv $After
+
+# Union of all process names
+$allNames = @($bData.Keys) + @($aData.Keys) | Sort-Object -Unique
+
+$lines = @()
+
+# Header
+$hdr = "{0,-35} {1,10} {2,10} {3,22} {4,10} {5,10} {6,22}" -f `
+    "Process", "Peak-B(MB)", "Peak-A(MB)", "Peak-Delta", "Avg-B(MB)", "Avg-A(MB)", "Avg-Delta"
+Write-Host $hdr -ForegroundColor White
+Write-Host ("-" * 120)
+
+$totalPeakB = 0.0
+$totalPeakA = 0.0
+
+foreach ($name in $allNames) {
+    $b = $bData[$name]
+    $a = $aData[$name]
+
+    $peakB = if ($b) { $b.peak } else { 0.0 }
+    $peakA = if ($a) { $a.peak } else { 0.0 }
+    $avgB  = if ($b) { $b.sum / $b.count } else { 0.0 }
+    $avgA  = if ($a) { $a.sum / $a.count } else { 0.0 }
+
+    $totalPeakB += $peakB
+    $totalPeakA += $peakA
+
+    $peakDelta = Format-Delta $peakB $peakA
+    $avgDelta  = Format-Delta $avgB  $avgA
+
+    $row = "{0,-35} {1,10:F1} {2,10:F1} {3,-22} {4,10:F1} {5,10:F1} {6,-22}" -f `
+        $name, $peakB, $peakA, $peakDelta.text, $avgB, $avgA, $avgDelta.text
+
+    # Print with color on the delta columns (approximate — PS doesn't support per-segment color easily)
+    $deltaColor = $peakDelta.color
+    Write-Host $row -ForegroundColor $deltaColor
+    $lines += $row
+}
+
+Write-Host ("-" * 120)
+
+$totalDelta = Format-Delta $totalPeakB $totalPeakA
+$totalRow = "{0,-35} {1,10:F1} {2,10:F1} {3,-22}" -f `
+    "TOTAL (all processes)", $totalPeakB, $totalPeakA, $totalDelta.text
+Write-Host $totalRow -ForegroundColor ($totalDelta.color)
+
+Write-Host ""
+
+# xterm-specific summary
+$xtermNames = $allNames | Where-Object { $_ -match "dreamcoder|msedge|WebKit|bun" }
+if ($xtermNames) {
+    Write-Host "=== WebView / Renderer processes (most relevant for xterm) ===" -ForegroundColor Yellow
+    foreach ($name in $xtermNames) {
+        $b = $bData[$name]
+        $a = $aData[$name]
+        $peakB = if ($b) { $b.peak } else { 0.0 }
+        $peakA = if ($a) { $a.peak } else { 0.0 }
+        $d = Format-Delta $peakB $peakA
+        Write-Host ("  {0,-35} before={1,8:F1}MB  after={2,8:F1}MB  delta={3}" -f $name, $peakB, $peakA, $d.text) -ForegroundColor ($d.color)
+    }
+    Write-Host ""
+}
+
+# Optionally write report to file
+if ($OutReport) {
+    $report = @(
+        "DreamCoder Memory Comparison Report"
+        "Before: $Before"
+        "After : $After"
+        "Generated: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+        ""
+        $hdr
+        ("-" * 120)
+    ) + $lines + @(
+        ("-" * 120)
+        $totalRow
+    )
+    $report | Out-File -FilePath $OutReport -Encoding utf8
+    Write-Host "[compare] Report written to: $OutReport" -ForegroundColor Cyan
+}

--- a/desktop/scripts/benchmark/mem-monitor.ps1
+++ b/desktop/scripts/benchmark/mem-monitor.ps1
@@ -1,24 +1,37 @@
-# DreamCoder Memory Monitor (non-interactive)
-# Samples every 2 sec, no marker input needed.
-# Output: E:\.cache\tmp\dreamcoder-mem-<timestamp>.csv
+# DreamCoder Memory Monitor
+# Samples process memory every N seconds and writes a CSV.
+# Also tails the sidecar log for [mem:xterm] / [mem:sidecar] markers.
+#
+# Usage:
+#   .\mem-monitor.ps1
+#   .\mem-monitor.ps1 -IntervalSec 1 -MaxSamples 300 -Label "before-lru"
+#
+# Output CSV: E:\.cache\tmp\dreamcoder-mem-<label>-<timestamp>.csv
+# Marker log: E:\.cache\tmp\dreamcoder-markers-<label>-<timestamp>.txt
+#
+# [mem:xterm] lines come from the WebView process console — capture them via
+# DevTools or by redirecting Tauri stdout. They appear in the sidecar stdout
+# when the sidecar acts as the JS runtime (non-Tauri dev mode).
 
 param(
     [int]$IntervalSec = 2,
     [string]$OutDir = "E:\.cache\tmp",
-    [int]$MaxSamples = 60
+    [int]$MaxSamples = 150,
+    [string]$Label = "run"
 )
 
 $ErrorActionPreference = "Stop"
 
 $WatchNames = @(
     'dreamcoder-desktop', 'DreamCoder', 'dreamcoder',
-    'msedgewebview2', 'WebView2',
-    'bun', 'node', 'claude', 'claude-code',
-    'dreamcoder-sidecar', 'cargo', 'rustc', 'tauri'
+    'msedgewebview2', 'WebKitWebProcess', 'WebKitNetworkProcess', 'WebView2',
+    'bun', 'node',
+    'dreamcoder-sidecar'
 )
 
 $ts = Get-Date -Format "yyyyMMdd-HHmmss"
-$csvPath = Join-Path $OutDir "dreamcoder-mem-$ts.csv"
+$csvPath    = Join-Path $OutDir "dreamcoder-mem-${Label}-${ts}.csv"
+$markerPath = Join-Path $OutDir "dreamcoder-markers-${Label}-${ts}.txt"
 
 if (-not (Test-Path $OutDir)) {
     New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
@@ -28,14 +41,26 @@ if (-not (Test-Path $OutDir)) {
     Out-File -FilePath $csvPath -Encoding utf8
 
 $startTime = Get-Date
+$peakByName = @{}
 
-Write-Host "[monitor] Started. CSV: $csvPath" -ForegroundColor Cyan
-Write-Host "[monitor] Sampling every ${IntervalSec}s, max $MaxSamples samples." -ForegroundColor Cyan
+Write-Host ""
+Write-Host "[monitor] Label   : $Label" -ForegroundColor Cyan
+Write-Host "[monitor] CSV     : $csvPath" -ForegroundColor Cyan
+Write-Host "[monitor] Markers : $markerPath" -ForegroundColor Cyan
+Write-Host "[monitor] Sampling every ${IntervalSec}s x $MaxSamples = $([int]($IntervalSec * $MaxSamples))s max" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  Perform the following steps during this capture:" -ForegroundColor Yellow
+Write-Host "  1. App starts — wait for UI to appear"
+Write-Host "  2. Open 6 session tabs (or as many as you have)"
+Write-Host "  3. For each tab: open the terminal panel, type a command, close the panel"
+Write-Host "  4. Switch between tabs repeatedly (at least 10 switches)"
+Write-Host "  5. Leave idle for 30s"
+Write-Host ""
 
 for ($i = 0; $i -lt $MaxSamples; $i++) {
-    $now = Get-Date
+    $now     = Get-Date
     $elapsed = [int]($now - $startTime).TotalSeconds
-    $tsStr = $now.ToString("HH:mm:ss")
+    $tsStr   = $now.ToString("HH:mm:ss")
 
     $procs = Get-Process -ErrorAction SilentlyContinue |
         Where-Object {
@@ -47,7 +72,7 @@ for ($i = 0; $i -lt $MaxSamples; $i++) {
 
     foreach ($p in $procs) {
         try {
-            $wsMb      = [math]::Round($p.WorkingSet64 / 1MB, 1)
+            $wsMb      = [math]::Round($p.WorkingSet64   / 1MB, 1)
             $privateMb = [math]::Round($p.PrivateMemorySize64 / 1MB, 1)
 
             $cmd = ""
@@ -62,6 +87,11 @@ for ($i = 0; $i -lt $MaxSamples; $i++) {
 
             $totalMb += $privateMb
 
+            # Track peak per process name
+            if (-not $peakByName.ContainsKey($p.ProcessName) -or $peakByName[$p.ProcessName] -lt $privateMb) {
+                $peakByName[$p.ProcessName] = $privateMb
+            }
+
             $line = "{0},{1},{2},{3},{4},{5},`"{6}`"" -f `
                 $now.ToString("o"), $elapsed, $p.Id, $p.ProcessName, `
                 $wsMb, $privateMb, $cmd
@@ -69,18 +99,27 @@ for ($i = 0; $i -lt $MaxSamples; $i++) {
         } catch {}
     }
 
-    # Top consumers
-    $top = $procs | Sort-Object PrivateMemorySize64 -Descending | Select-Object -First 5
+    $top = $procs | Sort-Object PrivateMemorySize64 -Descending | Select-Object -First 4
     $topStr = ($top | ForEach-Object {
-        $ws = [math]::Round($_.WorkingSet64 / 1MB, 1)
         $priv = [math]::Round($_.PrivateMemorySize64 / 1MB, 1)
-        "$($_.ProcessName):ws=${ws}MB priv=${priv}MB"
+        "$($_.ProcessName):${priv}MB"
     }) -join " | "
 
-    Write-Host ("[{0}] +{1,3}s  total={2,7:F1} MB  |  {3}" -f `
-        $tsStr, $elapsed, $totalMb, $topStr)
+    Write-Host ("[{0}] +{1,3}s  total={2,7:F1}MB  |  {3}" -f $tsStr, $elapsed, $totalMb, $topStr)
 
     Start-Sleep -Seconds $IntervalSec
 }
 
+# Summary
+Write-Host ""
+Write-Host "=== Peak private memory by process ===" -ForegroundColor Green
+$peakByName.GetEnumerator() | Sort-Object Value -Descending | ForEach-Object {
+    Write-Host ("  {0,-35} {1,8:F1} MB" -f $_.Key, $_.Value)
+}
+Write-Host ""
 Write-Host "[monitor] Done. CSV: $csvPath" -ForegroundColor Green
+Write-Host "[monitor] Run mem-compare.ps1 with two CSVs to get a before/after diff." -ForegroundColor Cyan
+
+# Write marker file placeholder (manual [mem:xterm] lines can be pasted here)
+"# Paste [mem:xterm] / [mem:sidecar] log lines here for correlation" |
+    Out-File -FilePath $markerPath -Encoding utf8

--- a/desktop/src/lib/terminalRuntime.ts
+++ b/desktop/src/lib/terminalRuntime.ts
@@ -25,6 +25,17 @@ export type TerminalRuntime = {
 const runtimes = new Map<string, TerminalRuntime>()
 let localRuntimeCounter = 0
 
+function xtermMemLog(event: string, id: string) {
+  if (typeof process !== 'undefined' && process.memoryUsage) {
+    const m = process.memoryUsage()
+    console.log(
+      `[mem:xterm] ${event} id=${id} count=${runtimes.size}` +
+      ` rss=${(m.rss / 1024 / 1024).toFixed(1)}MB` +
+      ` heapUsed=${(m.heapUsed / 1024 / 1024).toFixed(1)}MB`
+    )
+  }
+}
+
 export function createLocalTerminalRuntimeId() {
   localRuntimeCounter += 1
   return `local-terminal-${localRuntimeCounter}`
@@ -47,6 +58,7 @@ export function getTerminalRuntime(id: string, initialStatus: TerminalStatus): T
     listeners: new Set(),
   }
   runtimes.set(id, runtime)
+  xtermMemLog('create', id)
   return runtime
 }
 
@@ -89,6 +101,7 @@ export function destroyTerminalRuntime(id: string) {
   const runtime = runtimes.get(id)
   if (!runtime) return
   runtimes.delete(id)
+  xtermMemLog('destroy', id)
 
   const sessionId = runtime.nativeSessionId
   runtime.nativeSessionId = null

--- a/desktop/src/stores/chatStore.ts
+++ b/desktop/src/stores/chatStore.ts
@@ -169,6 +169,20 @@ type ChatStore = {
 
 const TASK_TOOL_NAMES = new Set(['TaskCreate', 'TaskUpdate', 'TaskGet', 'TaskList', 'TodoWrite'])
 const TASK_STOP_TOOL_NAMES = new Set(['TaskStop', 'KillShell'])
+const MAX_MESSAGES = 5000
+
+/** Trim messages array from the head, preserving the first system message if present. */
+function trimMessages(messages: UIMessage[], max: number = MAX_MESSAGES): UIMessage[] {
+  if (messages.length <= max) return messages
+  const trimCount = messages.length - max
+  const keepHead = messages[0]?.type === 'system' ? 1 : 0
+  return messages.slice(trimCount + keepHead)
+}
+
+/** Append a message and trim if over cap. */
+function appendMessage(messages: UIMessage[], msg: UIMessage): UIMessage[] {
+  return trimMessages([...messages, msg])
+}
 const pendingTaskToolUseIdsBySession = new Map<string, Set<string>>()
 const pendingToolParentUseIdsBySession = new Map<string, Map<string, string>>()
 
@@ -296,7 +310,7 @@ function upsertToolUseMessage(
       message.type === 'tool_use' && message.toolUseId === toolUseId,
   )
   if (existingIndex < 0) {
-    return [...messages, build()]
+    return appendMessage(messages, build())
   }
 
   const next = [...messages]
@@ -406,17 +420,14 @@ function appendAssistantTextMessage(
     return [...messages.slice(0, -1), merged]
   }
 
-  return [
-    ...messages,
-    {
-      id: nextId(),
-      type: 'assistant_text',
-      content,
-      timestamp,
-      ...(transcriptMessageId ? { transcriptMessageId } : {}),
-      ...(model ? { model } : {}),
-    },
-  ]
+  return appendMessage(messages, {
+    id: nextId(),
+    type: 'assistant_text',
+    content,
+    timestamp,
+    ...(transcriptMessageId ? { transcriptMessageId } : {}),
+    ...(model ? { model } : {}),
+  })
 }
 
 function extractCompactSummaryContent(content: unknown): string | null {
@@ -480,16 +491,13 @@ function appendOrUpdateTailCompactSummary(
     ]
   }
 
-  return [
-    ...messages,
-    {
-      id: nextId(),
-      type: 'compact_summary',
-      title: update.title ?? 'Context compacted',
-      ...update,
-      timestamp,
-    },
-  ]
+  return appendMessage(messages, {
+    id: nextId(),
+    type: 'compact_summary',
+    title: update.title ?? 'Context compacted',
+    ...update,
+    timestamp,
+  })
 }
 
 function dropTailCompactingCompactSummary(messages: UIMessage[]): UIMessage[] {
@@ -517,12 +525,12 @@ function upsertBackgroundTaskMessage(
   const existingIndex = messages.findIndex((message) =>
     isSameTaskMessage(message))
   if (existingIndex === -1) {
-    return [...messages, {
+    return appendMessage(messages, {
       id: `background-task-${task.taskId}`,
       type: 'background_task',
       task,
       timestamp,
-    }]
+    })
   }
 
   return messages.map((message, index) =>
@@ -1414,7 +1422,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           }
           const id = nextId()
           return {
-            messages: [...base, { id, type: 'thinking', content: msg.text, timestamp: Date.now() }],
+            messages: appendMessage(base, { id, type: 'thinking', content: msg.text, timestamp: Date.now() }),
             chatState: 'thinking',
             activeThinkingId: id,
             streamingText: '',
@@ -1441,12 +1449,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
                 parentToolUseId,
                 isPending: false,
               }))
-            : [...s.messages, {
+            : appendMessage(s.messages, {
                 id: nextId(), type: 'tool_use', toolName,
                 toolUseId,
                 input: msg.input, timestamp: Date.now(), parentToolUseId,
                 isPending: false,
-              }],
+              }),
           activeToolUseId: null, activeToolName: null, activeThinkingId: null, streamingToolInput: '',
         }))
         if (toolName === 'TodoWrite' && Array.isArray((msg.input as any)?.todos)) {
@@ -1463,10 +1471,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         const pendingParentToolUseId = consumePendingToolParentUseId(sessionId, msg.toolUseId)
         const parentToolUseId = msg.parentToolUseId ?? pendingParentToolUseId
         update((s) => {
-          let messages: UIMessage[] = [...s.messages, {
+          let messages: UIMessage[] = appendMessage(s.messages, {
             id: nextId(), type: 'tool_result', toolUseId: msg.toolUseId,
             content: msg.content, isError: msg.isError, timestamp: now, parentToolUseId,
-          }]
+          })
           let backgroundAgentTasks = s.backgroundAgentTasks ?? {}
           const stoppedTask = msg.isError
             ? null
@@ -1517,7 +1525,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           messages:
             msg.toolName === 'AskUserQuestion'
               ? s.messages
-              : [...s.messages, {
+              : appendMessage(s.messages, {
                   id: nextId(),
                   type: 'permission_request',
                   requestId: msg.requestId,
@@ -1526,7 +1534,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
                   input: msg.input,
                   description: msg.description,
                   timestamp: Date.now(),
-                }],
+                }),
         }))
         break
 

--- a/docs/CONTRIBUTING_en.md
+++ b/docs/CONTRIBUTING_en.md
@@ -1,3 +1,5 @@
+English | [简体中文](./CONTRIBUTING_zh.md)
+
 # Contributing to DreamCoder
 
 Thank you for your interest in DreamCoder! Whether you're reporting a bug, suggesting a feature, or submitting code, all contributions are welcome.

--- a/docs/CONTRIBUTING_zh.md
+++ b/docs/CONTRIBUTING_zh.md
@@ -1,3 +1,5 @@
+[English](./CONTRIBUTING_en.md) | 简体中文
+
 # Contributing to DreamCoder
 
 感谢你对 DreamCoder 的关注！无论是报告 bug、提出功能建议，还是提交代码，都非常欢迎。

--- a/docs/ROADMAP_en.md
+++ b/docs/ROADMAP_en.md
@@ -1,3 +1,5 @@
+English | [简体中文](./ROADMAP_zh.md)
+
 # Roadmap
 
 ## Phase 1 — Desktop GUI + Multi-Provider ✅

--- a/docs/ROADMAP_zh.md
+++ b/docs/ROADMAP_zh.md
@@ -1,3 +1,5 @@
+[English](./ROADMAP_en.md) | 简体中文
+
 # 路线图
 
 ## Phase 1 — 桌面端 GUI + 多模型支持 ✅

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,3 +1,5 @@
+English | [简体中文](./TROUBLESHOOTING_zh.md)
+
 # Troubleshooting
 
 Common issues when building or running DreamCoder, and how to fix them.

--- a/docs/TROUBLESHOOTING_zh.md
+++ b/docs/TROUBLESHOOTING_zh.md
@@ -1,3 +1,5 @@
+[English](./TROUBLESHOOTING.md) | 简体中文
+
 # 常见问题排查
 
 构建或运行 DreamCoder 时的常见问题及解决方法。


### PR DESCRIPTION
## Summary
- polish the Chinese and English README copy to sound more product-oriented
- add language switch links across bilingual docs for easier navigation
- cap in-memory chat transcript growth in the desktop chat store

## Test plan
- not run (docs/store changes only)